### PR TITLE
Updates note on disabling 2FA

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -553,7 +553,7 @@
                     <p>If you do not know what the developer account login details are please contact your organization's IT team.</p>
                   </div>
                   <div class="alert alert-warning">
-                    <p><strong>Note</strong> Two-Factor Authentication is not currently supported. Apple does not allow disabling Two-Factor Authentication. We recommend creating an account that without enabling Two-Factor Authentication that can be used with Fliplet.</p>
+                    <p><strong>Note</strong> If your account has Two-Factor Authentication enabled and you can't turn it off, please ask your IT to create a secondary account without 2FA to be used with Fliplet.</p>
                   </div>
 
                   <div class="form-group clearfix">

--- a/interface.html
+++ b/interface.html
@@ -553,7 +553,7 @@
                     <p>If you do not know what the developer account login details are please contact your organization's IT team.</p>
                   </div>
                   <div class="alert alert-warning">
-                    <p><strong>Note</strong> Two-Factor Authentication is not currently supported.</p>
+                    <p><strong>Note</strong> Two-Factor Authentication is not currently supported. Apple does not allow disabling Two-Factor Authentication. We recommend creating an account that without enabling Two-Factor Authentication that can be used with Fliplet.</p>
                   </div>
 
                   <div class="form-group clearfix">


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/3261

> Two-Factor Authentication is not currently supported. Apple does not allow disabling Two-Factor Authentication. We recommend creating an account that without enabling Two-Factor Authentication that can be used with Fliplet

**EDIT** Updated to

> If your account has Two-Factor Authentication enabled and you can't turn it off, please ask your IT to create a secondary account without 2FA to be used with Fliplet.