### PR TITLE
Removes expired warning text for privacy policy URL

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -513,7 +513,6 @@
                   <div class="col-sm-8">
                     <input type="text" name="fl-store-privacy" class="form-control" id="fl-store-privacy" pattern="^https?:\/\/([^ ]+)+" data-error="Please enter your Privacy Policy URL" required />
                     <div class="help-block with-errors"></div>
-                    <div class="alert alert-warning">Starting October 3, 2018, Apple will require a privacy policy URL for all new apps and app update submissions.</div>
                   </div>
                 </div>
                 <div class="form-group clearfix">


### PR DESCRIPTION
Removes the warning text below

![image](https://user-images.githubusercontent.com/290733/46666332-511ed500-cbbe-11e8-8bd6-d64ed55e997b.png)
