### PR TITLE
Add support for 2FA code in Apple logins when requested

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -22,7 +22,9 @@
 .enterprise-previous-file-success,
 .enterprise-generate-file,
 .enterprise-generate-file-success,
-.enterprise-upload-file {
+.enterprise-upload-file,
+.select-proxy-display[for="fl-store-teams"],
+.select-proxy-display[for="fl-ent-teams"] {
   display: none;
 }
 

--- a/interface.html
+++ b/interface.html
@@ -599,7 +599,7 @@
                       <label>Select a Developer Account Team</label>
                     </div>
                     <div class="col-sm-8">
-                      <button class="btn btn-secondary" id="fl-load-store-teams">Load teams</button>
+                      <a class="btn btn-secondary" id="fl-load-store-teams" href="#">Load teams</a>
                       <label for="fl-store-teams" class="select-proxy-display">
                         <select class="hidden-select form-control appStore-team" id="fl-store-teams" data-label="select">
                           <option value="">-- Select a team</option>
@@ -1254,7 +1254,7 @@ If you have any questions please reply and I will be happy to answer any questio
                       <label>Select a Developer Account Team</label>
                     </div>
                     <div class="col-sm-8">
-                      <button class="btn btn-secondary" id="fl-load-ent-teams">Load teams</button>
+                      <a class="btn btn-secondary" id="fl-load-ent-teams" href="#">Load teams</a>
                       <label for="fl-ent-teams" class="select-proxy-display">
                         <select class="hidden-select form-control enterprise-team" id="fl-ent-teams" data-label="select">
                           <option value="">-- Select a team</option>

--- a/interface.html
+++ b/interface.html
@@ -551,9 +551,6 @@
                   <div class="alert alert-info">
                     <p>If you do not know what the developer account login details are please contact your organization's IT team.</p>
                   </div>
-                  <div class="alert alert-warning">
-                    <p><strong>Note</strong> If your account has Two-Factor Authentication enabled and you can't turn it off, please ask IT to <a href="https://help.fliplet.com/article/39-how-to-configure-your-apple-developer-accounts" target="_blank">create a secondary account without 2FA</a> to be used with Fliplet.</p>
-                  </div>
 
                   <div class="form-group clearfix">
                     <div class="col-sm-4 control-label">
@@ -602,12 +599,13 @@
                       <label>Select a Developer Account Team</label>
                     </div>
                     <div class="col-sm-8">
-                       <label for="fl-store-teams" class="select-proxy-display">
-                          <select class="hidden-select form-control appStore-team" id="fl-store-teams" data-label="select">
-                            <option value="">-- Select a team</option>
-                          </select>
-                          <span class="icon fa fa-chevron-down"></span>
-                        </label>
+                      <button class="btn btn-secondary" id="fl-load-store-teams">Load teams</button>
+                      <label for="fl-store-teams" class="select-proxy-display">
+                        <select class="hidden-select form-control appStore-team" id="fl-store-teams" data-label="select">
+                          <option value="">-- Select a team</option>
+                        </select>
+                        <span class="icon fa fa-chevron-down"></span>
+                      </label>
                     </div>
                   </div>
                 </div>
@@ -1146,9 +1144,6 @@ If you have any questions please reply and I will be happy to answer any questio
                   <div class="alert alert-info">
                     <p>If you don't know what the developer account login details are please contact your organization's IT team.</p>
                   </div>
-                  <div class="alert alert-warning">
-                    <p><strong>Note</strong> Two-Factor Authentication is not currently supported.</p>
-                  </div>
                   <div class="form-group clearfix">
                     <div class="col-sm-4 control-label">
                       <label for="fl-ent-appDevLogin">Apple Developer account login</label>
@@ -1259,12 +1254,13 @@ If you have any questions please reply and I will be happy to answer any questio
                       <label>Select a Developer Account Team</label>
                     </div>
                     <div class="col-sm-8">
-                       <label for="fl-ent-teams" class="select-proxy-display">
-                          <select class="hidden-select form-control enterprise-team" id="fl-ent-teams" data-label="select">
-                            <option value="">-- Select a team</option>
-                          </select>
-                          <span class="icon fa fa-chevron-down"></span>
-                        </label>
+                      <button class="btn btn-secondary" id="fl-load-ent-teams">Load teams</button>
+                      <label for="fl-ent-teams" class="select-proxy-display">
+                        <select class="hidden-select form-control enterprise-team" id="fl-ent-teams" data-label="select">
+                          <option value="">-- Select a team</option>
+                        </select>
+                        <span class="icon fa fa-chevron-down"></span>
+                      </label>
                     </div>
                   </div>
                 </div>

--- a/js/interface.js
+++ b/js/interface.js
@@ -40,6 +40,7 @@ var screenShotsMobile = [];
 var screenShotsTablet = [];
 var haveScreenshots = false;
 var screenshotValidationNotRequired = false;
+var socket = Fliplet.Socket({ login: true });
 
 /* FUNCTIONS */
 String.prototype.toCamelCase = function() {
@@ -2822,3 +2823,12 @@ function initialLoad(initial, timeout) {
 
 // Start
 initLoad = initialLoad(true, 0);
+
+// Listen for 2FA code when requested
+socket.on('aab.apple.login.2fa', function (data) {
+  // Ask user for code
+  var code = prompt('Please type the 2FA code to log in');
+
+  // Notify requester with the code
+  socket.to(data.clientId).emit('aab.apple.login.2fa.code', code);
+});

--- a/js/interface.js
+++ b/js/interface.js
@@ -1120,14 +1120,12 @@ function cloneCredentials(organizationId, credentialKey, submission, saveData) {
 
 function setCredentials(organizationId, id, data, verify) {
   verify = typeof verify === 'undefined' ? true : verify;
+
   return Fliplet.API.request({
     method: 'PUT',
     url: 'v1/organizations/' + organizationId + '/credentials/submission-' + id + '?verify=' + verify,
     data: data
-  })
-  .then(function() {
-    return Promise.resolve();
-  })
+  });
 }
 
 function getTeams(organizationId, id, isItunes) {

--- a/js/interface.js
+++ b/js/interface.js
@@ -2128,6 +2128,12 @@ $('#appStoreConfiguration, #enterpriseConfiguration, #unsignedConfiguration').on
 });
 
 $('#appStoreConfiguration').validator().on('submit', function(event) {
+  if (_.includes(['fl-store-appDevLogin', 'fl-store-appDevPass'], document.activeElement.id)) {
+    // User submitted app store login form
+    $('.login-appStore-button').trigger('click');
+    return;
+  }
+
   if (event.isDefaultPrevented()) {
     // Gives time to Validator to apply classes
     setTimeout(checkGroupErrors, 0);
@@ -2205,6 +2211,12 @@ $('#appStoreConfiguration').validator().on('submit', function(event) {
 });
 
 $('#enterpriseConfiguration').validator().on('submit', function(event) {
+  if (_.includes(['fl-ent-appDevLogin', 'fl-ent-appDevPass'], document.activeElement.id)) {
+    // User submitted enterprise login form
+    $('.login-enterprise-button').trigger('click');
+    return;
+  }
+
   if (event.isDefaultPrevented()) {
     // Gives time to Validator to apply classes
     setTimeout(checkGroupErrors, 0);

--- a/js/interface.js
+++ b/js/interface.js
@@ -2851,7 +2851,7 @@ socket.on('aab.apple.login.2fa', function (data) {
   // Ask user for code
   prompt2FACode().then(function (code) {
     if (code === null) {
-      socket.to(data.clientId).emit('aab.apple.login.2fa.cancel', code);
+      socket.to(data.clientId).emit('aab.apple.login.2fa.cancel');
       return;
     }
 

--- a/js/interface.js
+++ b/js/interface.js
@@ -442,7 +442,6 @@ function enterpriseTeamSetup(devEmail, loginButton) {
 }
 
 function loadUnsignedData() {
-
   $('#unsignedConfiguration [name]').each(function(i, el) {
     var name = $(el).attr("name");
 
@@ -2905,8 +2904,6 @@ socket.on('aab.apple.login.2fa', function (data) {
 });
 
 socket.on('aab.apple.login.2fa.devices', function (data) {
-  console.log('Devices', data.devices);
-
   select2FAMethod(data).then(function (selection) {
     if (selection === null) {
       on2FACancel();

--- a/js/interface.js
+++ b/js/interface.js
@@ -2836,7 +2836,7 @@ function prompt2FACode() {
 
     if (code === '') {
       return Fliplet.Modal.alert({
-        message: 'You must enter the verifiaction code to log in'
+        message: 'You must enter the verification code to log in'
       }).then(function () {
         return prompt2FACode();
       });

--- a/js/interface.js
+++ b/js/interface.js
@@ -48,7 +48,7 @@ var socket = Fliplet.Socket({
 });
 
 /* FUNCTIONS */
-String.prototype.toCamelCase = function() {
+String.prototype.toCamelCase = function () {
   return this.replace(/^([A-Z])|[^A-Za-z]+(\w)/g, function(match, p1, p2, offset) {
     if (p2) return p2.toUpperCase();
     return p1.toLowerCase();
@@ -320,7 +320,7 @@ function loadAppStoreTeams(devEmail) {
       var teamId = $('#fl-store-teams').val();
       var teamName = teamId ? $('#fl-store-teams').find(":selected").data('team-name') : '';
 
-      if(teamId) {
+      if (teamId) {
         $('.appStore-more-options').addClass('show');
       } else {
         $('.appStore-more-options').removeClass('show');
@@ -482,7 +482,7 @@ function loadEnterpriseTeams(devEmail) {
       var teamId = $('#fl-ent-teams').val();
       var teamName = teamId ? $('#fl-ent-teams').find(":selected").data('team-name') : '';
 
-      if(teamId) {
+      if (teamId) {
         $('.enterprise-more-options').addClass('show');
       } else {
         $('.enterprise-more-options').removeClass('show');
@@ -625,8 +625,8 @@ function submissionBuild(appSubmission, origin) {
 
     Fliplet.Widget.autosize();
 
-    setTimeout(function() {
-      $('.save-' + origin + '-request').fadeOut(250, function() {
+    setTimeout(function () {
+      $('.save-' + origin + '-request').fadeOut(250, function () {
         $('.save-' + origin + '-request').removeClass('saved');
         Fliplet.Widget.autosize();
       });
@@ -651,10 +651,10 @@ function save(origin, submission) {
       submission = _.extend(savedSubmission, submission);
       return Promise.resolve();
     })
-    .then(function() {
+    .then(function () {
       if (submission.status !== 'started') {
         var previousCredentials = submission.data['fl-credentials'];
-        if(submission.data.hasOwnProperty('fl-credentials')){
+        if (submission.data.hasOwnProperty('fl-credentials')) {
           delete submission.data['fl-credentials'];
         }
         return Fliplet.App.Submissions.create({
@@ -681,10 +681,10 @@ function save(origin, submission) {
             }
 
             return cloneCredentialsPromise.then(function () {
-              Fliplet.App.Submissions.update(newSubmission.id, newSubmission.data).then(function() {
+              Fliplet.App.Submissions.update(newSubmission.id, newSubmission.data).then(function () {
                 $('.save-' + origin + '-progress').addClass('saved');
 
-                setTimeout(function() {
+                setTimeout(function () {
                   $('.save-' + origin + '-progress').removeClass('saved');
                 }, 4000);
               });
@@ -692,10 +692,10 @@ function save(origin, submission) {
           });
       }
 
-      Fliplet.App.Submissions.update(submission.id, submission.data).then(function() {
+      Fliplet.App.Submissions.update(submission.id, submission.data).then(function () {
         $('.save-' + origin + '-progress').addClass('saved');
 
-        setTimeout(function() {
+        setTimeout(function () {
           $('.save-' + origin + '-progress').removeClass('saved');
         }, 4000);
       });
@@ -731,9 +731,9 @@ function requestBuild(origin, submission) {
       submission = _.extend(savedSubmission, submission);
       return Promise.resolve();
     })
-    .then(function() {
+    .then(function () {
       if (submission.status !== 'started') {
-        if(submission.data.hasOwnProperty('fl-credentials')){
+        if (submission.data.hasOwnProperty('fl-credentials')) {
           delete submission.data['fl-credentials'];
         }
         return Fliplet.App.Submissions.create({
@@ -763,7 +763,7 @@ function requestBuild(origin, submission) {
                 certificate: appStorePreviousCredential.certificate,
                 content: appStorePreviousCredential.content
               })
-                .then(function() {
+                .then(function () {
                   submissionBuild(newSubmission, origin);
                 });
             }
@@ -780,13 +780,13 @@ function requestBuild(origin, submission) {
               }
 
               return setCertificateP12(appStoreSubmission.id, formData)
-                .then(function() {
+                .then(function () {
                   return setCredentials(appStoreSubmission.id, {
                     teamId: teamID,
                     teamName: teamName
                   });
                 })
-                .then(function() {
+                .then(function () {
                   submissionBuild(newSubmission, origin);
                 });
             }
@@ -800,7 +800,7 @@ function requestBuild(origin, submission) {
                 certificate: enterprisePreviousCredential.certificate,
                 content: enterprisePreviousCredential.content
               })
-                .then(function() {
+                .then(function () {
                   submissionBuild(newSubmission, origin);
                 });
             }
@@ -821,16 +821,16 @@ function requestBuild(origin, submission) {
                 teamId: teamId,
                 teamName: teamName
               })
-                .then(function() {
+                .then(function () {
                   return setCertificateP12(enterpriseSubmission.id, formData)
                 })
-                .then(function() {
+                .then(function () {
                   return setCredentials(enterpriseSubmission.id, {
                     teamId: teamID,
                     teamName: teamName
                   });
                 })
-                .then(function() {
+                .then(function () {
                   submissionBuild(newSubmission, origin);
                 });
             }
@@ -839,7 +839,7 @@ function requestBuild(origin, submission) {
           });
       }
 
-      Fliplet.App.Submissions.update(submission.id, submission.data).then(function() {
+      Fliplet.App.Submissions.update(submission.id, submission.data).then(function () {
         // Check which type of certificate was given
         if (origin === "appStore" && appStoreSubmission.data['fl-store-distribution'] === 'previous-file' && appStorePreviousCredential) {
           return setCredentials(appStoreSubmission.id, {
@@ -850,7 +850,7 @@ function requestBuild(origin, submission) {
             certificate: appStorePreviousCredential.certificate,
             content: appStorePreviousCredential.content
           })
-            .then(function() {
+            .then(function () {
               submissionBuild(submission, origin);
             });
         }
@@ -867,13 +867,13 @@ function requestBuild(origin, submission) {
           }
 
           return setCertificateP12(appStoreSubmission.id, formData)
-            .then(function() {
+            .then(function () {
               return setCredentials(appStoreSubmission.id, {
                 teamId: teamID,
                 teamName: teamName
               });
             })
-            .then(function() {
+            .then(function () {
               submissionBuild(submission, origin);
             });
         }
@@ -887,7 +887,7 @@ function requestBuild(origin, submission) {
             certificate: enterprisePreviousCredential.certificate,
             content: enterprisePreviousCredential.content
           })
-            .then(function() {
+            .then(function () {
               submissionBuild(submission, origin);
             });
         }
@@ -904,13 +904,13 @@ function requestBuild(origin, submission) {
           }
 
           return setCertificateP12(enterpriseSubmission.id, formData)
-            .then(function() {
+            .then(function () {
               return setCredentials(enterpriseSubmission.id, {
                 teamId: teamID,
                 teamName: teamName
               });
             })
-            .then(function() {
+            .then(function () {
               submissionBuild(submission, origin);
             });
         }
@@ -1068,7 +1068,7 @@ function saveEnterpriseData(request) {
       });
     }
 
-    uploadFilePromise.then(function() {
+    uploadFilePromise.then(function () {
       enterpriseSubmission.data = data;
       notificationSettings = pushData;
 
@@ -1150,7 +1150,7 @@ function savePushData(silentSave) {
     method: 'PUT',
     url: 'v1/widget-instances/com.fliplet.push-notifications?appId=' + Fliplet.Env.get('appId'),
     data: notificationSettings
-  }).then(function() {
+  }).then(function () {
     $('.save-push-progress').addClass('saved');
     if (!notificationSettings.apn && !silentSave) {
       Fliplet.Modal.alert({
@@ -1162,7 +1162,7 @@ function savePushData(silentSave) {
       });
     }
 
-    setTimeout(function() {
+    setTimeout(function () {
       $('.save-push-progress').removeClass('saved');
     }, 4000);
   });
@@ -1175,7 +1175,7 @@ function cloneCredentials(credentialKey, submission, saveData) {
     data: {
       key: submission.data['fl-credentials']
     }
-  }).then(function() {
+  }).then(function () {
     if (saveData) {
       return Fliplet.App.Submissions.update(submission.id, submission.data);
     }
@@ -1216,10 +1216,10 @@ function searchCredentials(data) {
 }
 
 function getAppCredentials(credentialKey, teamId) {
-  if(credentialKey) {
+  if (credentialKey) {
     return getCredential(credentialKey)
       .then(function(credential) {
-        if(credential && credential.teamId === teamId && (credential.p12 || credential.certificate)) {
+        if (credential && credential.teamId === teamId && (credential.p12 || credential.certificate)) {
           return credential;
         }
 
@@ -1244,7 +1244,7 @@ function setAppStorePrevCredentials(credential) {
 }
 
 function refreshAppStoreOptions(devEmail, selectedTeamId, selectedTeamName) {
-  if(!selectedTeamId) {
+  if (!selectedTeamId) {
     setAppStorePrevCredentials();
     return;
   }
@@ -1252,7 +1252,7 @@ function refreshAppStoreOptions(devEmail, selectedTeamId, selectedTeamName) {
   return getAppCredentials(appStoreSubmission.data['fl-credentials'],
     selectedTeamId)
     .then(function(credential) {
-      if(credential) {
+      if (credential) {
         return credential;
       }
 
@@ -1273,7 +1273,7 @@ function refreshAppStoreOptions(devEmail, selectedTeamId, selectedTeamName) {
           });
         }
 
-        if(credentialKey) {
+        if (credentialKey) {
           return getCredential(credentialKey);
         }
 
@@ -1284,7 +1284,7 @@ function refreshAppStoreOptions(devEmail, selectedTeamId, selectedTeamName) {
       });
     })
     .then(function(credential) {
-      if(credential) {
+      if (credential) {
         return credential;
       }
 
@@ -1295,7 +1295,7 @@ function refreshAppStoreOptions(devEmail, selectedTeamId, selectedTeamName) {
       }
 
       //if we dont have any credentials we need to check previous result for a credential object
-      if(!_.isUndefined(previousResults) && (!_.isUndefined(previousResults.p12) || !_.isUndefined(previousResults.certificate)) && appStoreSubmission.data['fl-store-teamId'] === selectedTeamId) {
+      if (!_.isUndefined(previousResults) && (!_.isUndefined(previousResults.p12) || !_.isUndefined(previousResults.certificate)) && appStoreSubmission.data['fl-store-teamId'] === selectedTeamId) {
         return {
           teamId: selectedTeamId,
           teamName: selectedTeamName,
@@ -1330,7 +1330,7 @@ function setAppEnterprisePrevCredential(credential) {
 }
 
 function refreshAppEnterpriseOptions(devEmail, selectedTeamId, selectedTeamName) {
-  if(!selectedTeamId) {
+  if (!selectedTeamId) {
     setAppEnterprisePrevCredential();
     return;
   }
@@ -1338,7 +1338,7 @@ function refreshAppEnterpriseOptions(devEmail, selectedTeamId, selectedTeamName)
   return getAppCredentials(enterpriseSubmission.data['fl-credentials'],
     selectedTeamId)
     .then(function(credential) {
-      if(credential) {
+      if (credential) {
         return credential;
       }
 
@@ -1359,7 +1359,7 @@ function refreshAppEnterpriseOptions(devEmail, selectedTeamId, selectedTeamName)
           });
         }
 
-        if(credentialKey) {
+        if (credentialKey) {
           return getCredential(credentialKey);
         }
 
@@ -1370,7 +1370,7 @@ function refreshAppEnterpriseOptions(devEmail, selectedTeamId, selectedTeamName)
       });
     })
     .then(function(credential) {
-      if(credential) {
+      if (credential) {
         return credential;
       }
 
@@ -1381,7 +1381,7 @@ function refreshAppEnterpriseOptions(devEmail, selectedTeamId, selectedTeamName)
       }
 
       //if we dont have any credentials we need to check previous result for a credential object
-      if(!_.isUndefined(previousResults) && (!_.isUndefined(previousResults.p12) || !_.isUndefined(previousResults.certificate)) && enterpriseSubmission.data['fl-ent-teamId'] === selectedTeamId) {
+      if (!_.isUndefined(previousResults) && (!_.isUndefined(previousResults.p12) || !_.isUndefined(previousResults.certificate)) && enterpriseSubmission.data['fl-ent-teamId'] === selectedTeamId) {
         return {
           teamId: selectedTeamId,
           teamName: selectedTeamName,
@@ -1428,7 +1428,7 @@ function getCompletedSubmissions(devEmail, teamId, teamName) {
     url: url
   })
   .then(function(result) {
-    if(!result.submissions) {
+    if (!result.submissions) {
       return;
     }
 
@@ -1440,7 +1440,7 @@ function getCompletedSubmissions(devEmail, teamId, teamName) {
         )
     });
 
-    if(!_.isUndefined(latestSubmission)) {
+    if (!_.isUndefined(latestSubmission)) {
       return {
         teamId: teamId,
         teamName: teamName,
@@ -1765,7 +1765,7 @@ function submissionChecker(submissions) {
 
     appStoreSubmission.data['fl-credentials'] = 'submission-' + appStoreSubmission.id;
 
-    if(previousSubWithCredentials) {
+    if (previousSubWithCredentials) {
       cloneAppStoreCredentialsPromise = cloneCredentials(previousSubWithCredentials.data['fl-credentials'], appStoreSubmission, true);
     }
   }
@@ -1808,7 +1808,7 @@ function submissionChecker(submissions) {
 
     enterpriseSubmission.data['fl-credentials'] = 'submission-' + enterpriseSubmission.id;
 
-    if(previousSubWithCredentials) {
+    if (previousSubWithCredentials) {
       cloneEnterpriseCredentialsPromise = cloneCredentials(previousSubWithCredentials.data['fl-credentials'], enterpriseSubmission, true);
     }
   }
@@ -1912,7 +1912,7 @@ function getSubmissions() {
 
 function initialLoad(initial, timeout) {
   if (!initial) {
-    initLoad = setTimeout(function() {
+    initLoad = setTimeout(function () {
       getSubmissions()
         .then(function(submissions) {
           iosSubmissionChecker(submissions);
@@ -1963,7 +1963,7 @@ function initialLoad(initial, timeout) {
           return submissionChecker(submissions);
         });
       })
-      .then(function() {
+      .then(function () {
         // Fliplet.Env.get('appId')
         // Fliplet.Env.get('appName')
         // Fliplet.Env.get('appSettings')
@@ -1987,7 +1987,7 @@ function initialLoad(initial, timeout) {
           })
         ]);
       })
-      .then(function() {
+      .then(function () {
         if (appSettings.folderStructure) {
           var structure = [];
           hasFolders = true;
@@ -2007,7 +2007,7 @@ function initialLoad(initial, timeout) {
                 return Promise.resolve(structure);
               });
           }))
-          .then(function() {
+          .then(function () {
             structure.forEach(function(el, idx) {
               if (el.type === 'mobile') {
                 screenShotsMobile = el.folderContent.files
@@ -2022,7 +2022,7 @@ function initialLoad(initial, timeout) {
           return;
         }
       })
-      .then(function() {
+      .then(function () {
         return Fliplet.API.request({
           method: 'GET',
           url: 'v1/widget-instances/com.fliplet.push-notifications?appId=' + Fliplet.Env.get('appId')
@@ -2097,7 +2097,7 @@ function prompt2FA() {
 }
 
 /* ATTACH LISTENERS */
-$('[name="fl-store-screenshots"]').on('change', function() {
+$('[name="fl-store-screenshots"]').on('change', function () {
   var value = $(this).val();
   var id = $(this).attr('id');
   checkHasScreenshots();
@@ -2132,7 +2132,7 @@ $('[name="fl-store-screenshots"]').on('change', function() {
   }
 });
 
-$('[name="submissionType"]').on('change', function() {
+$('[name="submissionType"]').on('change', function () {
   var selectedOptionId = $(this).attr('id');
 
   $('.fl-sb-panel').removeClass('show');
@@ -2141,7 +2141,7 @@ $('[name="submissionType"]').on('change', function() {
   Fliplet.Widget.autosize();
 });
 
-$('[name="fl-store-credentials"]').on('change', function() {
+$('[name="fl-store-credentials"]').on('change', function () {
   var value = $(this).val();
 
   if (value === 'useOwn') {
@@ -2153,7 +2153,7 @@ $('[name="fl-store-credentials"]').on('change', function() {
   Fliplet.Widget.autosize();
 });
 
-$('.fl-sb-appStore [change-bundleid], .fl-sb-enterprise [change-bundleid], .fl-sb-unsigned [change-bundleid]').on('click', function() {
+$('.fl-sb-appStore [change-bundleid], .fl-sb-enterprise [change-bundleid], .fl-sb-unsigned [change-bundleid]').on('click', function () {
   Fliplet.Modal.confirm({
     message: 'Are you sure you want to change the unique Bundle ID?'
   }).then(function (confirmed) {
@@ -2169,18 +2169,18 @@ $('.fl-sb-appStore [change-bundleid], .fl-sb-enterprise [change-bundleid], .fl-s
 });
 
 $('.panel-group')
-  .on('shown.bs.collapse', '.panel-collapse', function() {
+  .on('shown.bs.collapse', '.panel-collapse', function () {
     Fliplet.Widget.autosize();
   })
-  .on('hidden.bs.collapse', '.panel-collapse', function() {
+  .on('hidden.bs.collapse', '.panel-collapse', function () {
     Fliplet.Widget.autosize();
   });
 
 $('a[data-toggle="tab"]')
-  .on('shown.bs.tab', function() {
+  .on('shown.bs.tab', function () {
     Fliplet.Widget.autosize();
   })
-  .on('hidden.bs.tab', function() {
+  .on('hidden.bs.tab', function () {
     Fliplet.Widget.autosize();
   });
 
@@ -2230,7 +2230,7 @@ $('[data-change-assets]').on('click', function(event) {
   });
 });
 
-$('#appStoreConfiguration, #enterpriseConfiguration, #unsignedConfiguration').on('validated.bs.validator', function() {
+$('#appStoreConfiguration, #enterpriseConfiguration, #unsignedConfiguration').on('validated.bs.validator', function () {
   checkGroupErrors();
   Fliplet.Widget.autosize();
 });
@@ -2276,7 +2276,7 @@ $('#appStoreConfiguration').validator().on('submit', function(event) {
           return;
         }
 
-        if (certificateKind === 'upload-file' && (!appStoreFileField.files || !appStoreFileField.files[0])){
+        if (certificateKind === 'upload-file' && (!appStoreFileField.files || !appStoreFileField.files[0])) {
           Fliplet.Modal.alert({
             message: 'You need to upload a certificate before requesting a submission'
           });
@@ -2453,21 +2453,21 @@ $('#unsignedConfiguration').validator().on('submit', function(event) {
 });
 
 /* SAVE PROGRESS CLICK */
-$('[data-app-store-save]').on('click', function() {
+$('[data-app-store-save]').on('click', function () {
   saveAppStoreData();
 });
-$('[data-enterprise-save]').on('click', function() {
+$('[data-enterprise-save]').on('click', function () {
   saveEnterpriseData();
 });
-$('[data-unsigned-save]').on('click', function() {
+$('[data-unsigned-save]').on('click', function () {
   saveUnsignedData();
 });
-$('[data-push-save]').on('click', function() {
+$('[data-push-save]').on('click', function () {
   savePushData();
 });
 
 /* Credentials and Certificates App Store */
-$('.login-appStore-button').on('click', function() {
+$('.login-appStore-button').on('click', function () {
   var $this = $(this);
   $(this).html('Logging in' + spinner);
   $(this).addClass('disabled');
@@ -2506,7 +2506,7 @@ $('.login-appStore-button').on('click', function() {
       email: devEmail,
       password: devPass
     })
-      .then(function() {
+      .then(function () {
         $this.html('Log in');
         $this.removeClass('disabled');
         return appStoreTeamSetup(devEmail, true);
@@ -2532,11 +2532,11 @@ $('.login-appStore-button').on('click', function() {
   }
 });
 
-$('.log-out-appStore').on('click', function() {
+$('.log-out-appStore').on('click', function () {
   clearAppStoreCredentials();
 });
 
-$('[name="fl-store-distribution"]').on('change', function() {
+$('[name="fl-store-distribution"]').on('change', function () {
   var value = $(this).val();
 
   $('#fl-store-teams').prop('required',true);
@@ -2597,7 +2597,7 @@ $('#fl-load-store-teams').on('click', function (e) {
     });
 });
 
-$('#fl-store-teams').on('change', function() {
+$('#fl-store-teams').on('change', function () {
   var value = $(this).val();
   var teamName = value ? $('#fl-store-teams').find(":selected").data('team-name') : '';
 
@@ -2615,7 +2615,7 @@ $('#fl-store-teams').on('change', function() {
   return refreshAppStoreOptions(devEmail, value, teamName);
 });
 
-$('.appStore-generate-cert').on('click', function() {
+$('.appStore-generate-cert').on('click', function () {
   var $this = $(this);
   $(this).html('Generating' + spinner);
   $(this).addClass('disabled');
@@ -2628,7 +2628,7 @@ $('.appStore-generate-cert').on('click', function() {
       teamId: teamId,
       teamName: teamName
     })
-    .then(function() {
+    .then(function () {
       return createCertificates({
         organizationId: organizationID,
         submissionId: appStoreSubmission.id
@@ -2653,7 +2653,7 @@ $('.appStore-generate-cert').on('click', function() {
     });
 });
 
-$('#fl-store-certificate').on('change', function() {
+$('#fl-store-certificate').on('change', function () {
   appStoreFileField = this;
   var fileName = appStoreFileField.value.replace(/\\/g, '/').replace(/.*\//, '');
 
@@ -2662,7 +2662,7 @@ $('#fl-store-certificate').on('change', function() {
   }
 });
 
-$('.appStore-replace-cert').on('click', function() {
+$('.appStore-replace-cert').on('click', function () {
   var $this = $(this);
   $(this).html('Replacing' + spinner);
   $(this).addClass('disabled');
@@ -2673,12 +2673,12 @@ $('.appStore-replace-cert').on('click', function() {
 
   if (appStorePreviousCredential.certificate && appStorePreviousCredential.certificate.id) {
     return revokeCertificate(appStoreSubmission.id, appStorePreviousCredential.certificate.id)
-      .then(function() {
+      .then(function () {
         return setCredentials(appStoreSubmission.id, {
             teamId: teamId,
             teamName: teamName
           })
-          .then(function() {
+          .then(function () {
             return createCertificates({
               organizationId: organizationID,
               submissionId: appStoreSubmission.id
@@ -2710,7 +2710,7 @@ $('.appStore-replace-cert').on('click', function() {
 /**/
 
 /* Credentials and Certificates Enterprise */
-$('.login-enterprise-button').on('click', function() {
+$('.login-enterprise-button').on('click', function () {
   var $this = $(this);
   $(this).html('Logging in' + spinner);
   $(this).addClass('disabled');
@@ -2749,7 +2749,7 @@ $('.login-enterprise-button').on('click', function() {
       email: devEmail,
       password: devPass
     })
-    .then(function() {
+    .then(function () {
       $('[name="fl-ent-distribution"][value="generate-file"]').prop('checked', true).trigger('change');
       $this.html('Log in');
       $this.removeClass('disabled');
@@ -2776,11 +2776,11 @@ $('.login-enterprise-button').on('click', function() {
   }
 });
 
-$('.log-out-enterprise').on('click', function() {
+$('.log-out-enterprise').on('click', function () {
   clearEnterpriseCredentials();
 });
 
-$('[name="fl-ent-distribution"]').on('change', function() {
+$('[name="fl-ent-distribution"]').on('change', function () {
   var value = $(this).val();
 
   $('#fl-ent-teams').prop('required',true);
@@ -2838,7 +2838,7 @@ $('#fl-load-ent-teams').on('click', function (e) {
     });
 });
 
-$('#fl-ent-teams').on('change', function() {
+$('#fl-ent-teams').on('change', function () {
   var value = $(this).val();
   var teamName = value ? $('#fl-ent-teams').find(":selected").data('team-name') : '';
 
@@ -2856,7 +2856,7 @@ $('#fl-ent-teams').on('change', function() {
   return refreshAppEnterpriseOptions(devEmail, value, teamName);
 });
 
-$('.enterprise-generate-cert').on('click', function() {
+$('.enterprise-generate-cert').on('click', function () {
   var $this = $(this);
   $(this).html('Generating' + spinner);
   $(this).addClass('disabled');
@@ -2869,7 +2869,7 @@ $('.enterprise-generate-cert').on('click', function() {
       teamId: teamId,
       teamName: teamName
     })
-    .then(function() {
+    .then(function () {
       return createCertificates({
         organizationId: organizationID,
         submissionId: enterpriseSubmission.id,
@@ -2895,7 +2895,7 @@ $('.enterprise-generate-cert').on('click', function() {
     });
 });
 
-$('#fl-ent-certificate').on('change', function() {
+$('#fl-ent-certificate').on('change', function () {
   enterpriseFileField = this;
   var fileName = enterpriseFileField.value.replace(/\\/g, '/').replace(/.*\//, '');
 
@@ -2904,7 +2904,7 @@ $('#fl-ent-certificate').on('change', function() {
   }
 });
 
-$('#fl-ent-certificate-manual-details').on('change', function() {
+$('#fl-ent-certificate-manual-details').on('change', function () {
   enterpriseFileFieldManual = this;
   var fileName = enterpriseFileFieldManual.value.replace(/\\/g, '/').replace(/.*\//, '');
 
@@ -2913,7 +2913,7 @@ $('#fl-ent-certificate-manual-details').on('change', function() {
   }
 });
 
-$('#fl-ent-mobileprovision-manual-details').on('change', function() {
+$('#fl-ent-mobileprovision-manual-details').on('change', function () {
   enterpriseFileProvisionFieldManual = this;
   var fileName = enterpriseFileProvisionFieldManual.value.replace(/\\/g, '/').replace(/.*\//, '');
 
@@ -2922,7 +2922,7 @@ $('#fl-ent-mobileprovision-manual-details').on('change', function() {
   }
 });
 
-$('.enterprise-replace-cert').on('click', function() {
+$('.enterprise-replace-cert').on('click', function () {
   var $this = $(this);
   $(this).html('Replacing' + spinner);
   $(this).addClass('disabled');
@@ -2933,12 +2933,12 @@ $('.enterprise-replace-cert').on('click', function() {
 
   if (enterprisePreviousCredential.certificate && enterprisePreviousCredential.certificate.id) {
     return revokeCertificate(enterpriseSubmission.id, enterprisePreviousCredential.certificate.id)
-      .then(function() {
+      .then(function () {
         return setCredentials(enterpriseSubmission.id, {
           teamId: teamId,
           teamName: teamName
         })
-          .then(function() {
+          .then(function () {
             return createCertificates({
               organiazationId: organizationID,
               submissionId: enterpriseSubmission.id,
@@ -2969,7 +2969,7 @@ $('.enterprise-replace-cert').on('click', function() {
   }
 });
 
-$('.ent-enter-manually').on('click', function() {
+$('.ent-enter-manually').on('click', function () {
   $('.enterprise-login-details').addClass('hidden');
   $('.enterprise-manual-details').addClass('show');
   enterpriseManual = true;
@@ -2984,7 +2984,7 @@ $('.ent-enter-manually').on('click', function() {
   $('#fl-ent-mobileprovision-manual-details').prop('required', true);
 });
 
-$('.enterprise-back-login').on('click', function() {
+$('.enterprise-back-login').on('click', function () {
   $('.enterprise-login-details').removeClass('hidden');
   $('.enterprise-manual-details').removeClass('show');
   enterpriseManual = false;
@@ -3000,14 +3000,14 @@ $('.enterprise-back-login').on('click', function() {
 });
 /**/
 
-$(document).on('click', '[data-cancel-build-id]', function() {
+$(document).on('click', '[data-cancel-build-id]', function () {
   var buildId = $(this).data('cancel-build-id');
 
   Fliplet.API.request({
     method: 'DELETE',
     url: 'v1/apps/' + Fliplet.Env.get('appId') + '/submissions/' + buildId
   })
-  .then(function() {
+  .then(function () {
     clearTimeout(initLoad);
     initialLoad(false, 0);
   })

--- a/js/interface.js
+++ b/js/interface.js
@@ -40,7 +40,11 @@ var screenShotsMobile = [];
 var screenShotsTablet = [];
 var haveScreenshots = false;
 var screenshotValidationNotRequired = false;
-var socket = Fliplet.Socket({ login: true });
+
+var socket = Fliplet.Socket({
+  transports: ['polling'], // avoid being blocked by AdBlockers
+  login: true
+});
 
 /* FUNCTIONS */
 String.prototype.toCamelCase = function() {

--- a/js/interface.js
+++ b/js/interface.js
@@ -1518,7 +1518,8 @@ function publishApp(context) {
       changelog: 'Initial version'
     }
   };
-  Fliplet.API.request({
+
+  return Fliplet.API.request({
     method: 'POST',
     url: 'v1/apps/' + Fliplet.Env.get('appId') + '/publish',
     data: options
@@ -1545,6 +1546,9 @@ function publishApp(context) {
       default:
         break;
     }
+  }).catch(function (err) {
+    Fliplet.Modal.alert({ message: Fliplet.parseError(err) });
+    return Promise.reject(err);
   });
 }
 
@@ -2232,9 +2236,14 @@ $('#appStoreConfiguration').validator().on('submit', function(event) {
       });
     }
   } else {
+    var initialHtml = $('.button-appStore-request').html();
     $('.button-appStore-request').html('Please wait <i class="fa fa-spinner fa-pulse fa-fw"></i>');
     $('.button-appStore-request').prop('disabled', true);
-    publishApp('appStore');
+
+    publishApp('appStore').catch(function () {
+      $('.button-appStore-request').html(initialHtml);
+      $('.button-appStore-request').prop('disabled', false);
+    });;
   }
 
   // Gives time to Validator to apply classes
@@ -2307,9 +2316,14 @@ $('#enterpriseConfiguration').validator().on('submit', function(event) {
       });
     }
   } else {
+    var initialHtml = $('.button-enterprise-request').html();
     $('.button-enterprise-request').html('Please wait <i class="fa fa-spinner fa-pulse fa-fw"></i>');
     $('.button-enterprise-request').prop('disabled', true);
-    publishApp('enterprise');
+
+    publishApp('enterprise').catch(function () {
+      $('.button-enterprise-request').html(initialHtml);
+      $('.button-enterprise-request').prop('disabled', false);
+    });
   }
 
   // Gives time to Validator to apply classes
@@ -2351,9 +2365,14 @@ $('#unsignedConfiguration').validator().on('submit', function(event) {
       });
     }
   } else {
+    var initialHtml = $('.button-unsigned-request').html();
     $('.button-unsigned-request').html('Please wait <i class="fa fa-spinner fa-pulse fa-fw"></i>');
     $('.button-unsigned-request').prop('disabled', true);
-    publishApp('unsigned');
+
+    publishApp('unsigned').catch(function () {
+      $('.button-unsigned-request').html(initialHtml);
+      $('.button-unsigned-request').prop('disabled', false);
+    });
   }
 
   // Gives time to Validator to apply classes

--- a/js/interface.js
+++ b/js/interface.js
@@ -1983,6 +1983,7 @@ function select2FADevice(data) {
 
   return Fliplet.Modal.prompt({
     title: 'Your Apple ID is protected with two-step verification. Choose a trusted device to receive a verification code.',
+    size: 'small',
     inputType: 'select',
     inputOptions: options
   }).then(function (selection) {
@@ -1992,7 +1993,8 @@ function select2FADevice(data) {
 
     if (selection === '') {
       return Fliplet.Modal.alert({
-        message: 'You must choose a device to continue.'
+        message: 'You must choose a device to continue.',
+        size: 'small'
       }).then(function () {
         return select2FADevice(data);
       });
@@ -2004,7 +2006,8 @@ function select2FADevice(data) {
 
 function prompt2FA() {
   return Fliplet.Modal.prompt({
-    title: 'A message with a verification code has been sent to your devices. Please enter the code to continue.<br><br>If you are not certain which devices to check, please contact your Apple account administrator or IT team.'
+    title: 'A message with a verification code has been sent to your devices. Please enter the code to continue.<div class="alert alert-info alert-sm"><strong>Note:</strong> If you are not certain which devices to check, please contact your Apple account administrator or IT team.</div>',
+    size: 'small'
   }).then(function (code) {
     if (code === null) {
       return null;
@@ -2012,7 +2015,8 @@ function prompt2FA() {
 
     if (code === '') {
       return Fliplet.Modal.alert({
-        message: 'You must enter the verification code to continue.'
+        message: 'You must enter the verification code to continue.',
+        size: 'small'
       }).then(function () {
         return prompt2FA();
       });

--- a/js/interface.js
+++ b/js/interface.js
@@ -2883,6 +2883,15 @@ socket.on('aab.apple.login.2fa', function (data) {
   });
 });
 
+socket.on('aab.apple.login.2fa.devices', function (data) {
+  console.log('Devices', data.devices);
+
+  // @TODO: select device
+  // Selected index should start from 1, not 0
+
+  socket.to(data.clientId).emit('aab.apple.login.2fa.device', 1);
+});
+
 // Listen for a 2FA code successfully entered
 socket.on('aab.apple.login.2fa.success', on2FASuccess);
 

--- a/js/interface.js
+++ b/js/interface.js
@@ -217,8 +217,6 @@ function loadAppStoreData() {
 
     allAppData.push('appStore');
   } else {
-    $('.app-details-appStore').addClass('required-fill');
-
     if (appName === '') {
       $('.app-details-appStore .app-list-name').addClass('has-error');
     }
@@ -229,11 +227,12 @@ function loadAppStoreData() {
       $('.app-details-appStore .app-splash-screen').addClass('has-warning');
     }
 
-    if (hasFolders) {
-      if (screenShotsMobile.length == 0 || screenShotsTablet.length == 0) {
-        $('.app-details-appStore .app-screenshots').addClass('has-error');
-      }
-    } else {
+    if ($('[name="fl-store-screenshots"]:checked').val() === 'new'
+      && (!hasFolders
+        || !screenShotsMobile.length
+        || !screenShotsTablet.length
+      )
+    ) {
       $('.app-details-appStore .app-screenshots').addClass('has-error');
     }
   }

--- a/js/interface.js
+++ b/js/interface.js
@@ -49,7 +49,7 @@ var socket = Fliplet.Socket({
 
 /* FUNCTIONS */
 String.prototype.toCamelCase = function () {
-  return this.replace(/^([A-Z])|[^A-Za-z]+(\w)/g, function(match, p1, p2, offset) {
+  return this.replace(/^([A-Z])|[^A-Za-z]+(\w)/g, function (match, p1, p2, offset) {
     if (p2) return p2.toUpperCase();
     return p1.toLowerCase();
   }).replace(/([^A-Z-a-z])/g, '').toLowerCase();
@@ -86,7 +86,7 @@ function addThumb(thumb) {
 }
 
 function loadAppStoreData() {
-  $('#appStoreConfiguration [name]').each(function(i, el) {
+  $('#appStoreConfiguration [name]').each(function (i, el) {
     var name = $(el).attr("name");
 
     var hasAppId = !_.isUndefined(appStoreSubmission.data['iTunesAppId']);
@@ -149,7 +149,7 @@ function loadAppStoreData() {
 
     /* ADD BUNDLE ID */
     if (name === "fl-store-bundleId" && typeof appStoreSubmission.data[name] === "undefined") {
-      createBundleID(organizationName.toCamelCase(), appName.toCamelCase()).then(function(response) {
+      createBundleID(organizationName.toCamelCase(), appName.toCamelCase()).then(function (response) {
         if (response.resultCount === 0) {
           $('.bundleId-ast-text').html('com.' + organizationName.toCamelCase() + '.' + appName.toCamelCase());
           $('[name="' + name + '"]').val('com.' + organizationName.toCamelCase() + '.' + appName.toCamelCase());
@@ -301,8 +301,8 @@ function loadAppStoreTeams(devEmail) {
       var itunesTeams = teams[0];
       var appStoreTeams = teams[1];
 
-      appStoreTeams = _.filter(appStoreTeams, function(team) {
-        var itunesTeam = _.find(itunesTeams, function(itcTeam) {
+      appStoreTeams = _.filter(appStoreTeams, function (team) {
+        var itunesTeam = _.find(itunesTeams, function (itcTeam) {
           return itcTeam.team_name === team.name;
         });
 
@@ -310,7 +310,7 @@ function loadAppStoreTeams(devEmail) {
       });
 
       var options = ['<option value="">-- Select a team</option>'];
-      appStoreTeams.forEach(function(team, i) {
+      appStoreTeams.forEach(function (team, i) {
         options.push('<option value="' + team.teamId + '" data-team-name="' + team.name + '">'+ team.name + ' - ' + team.teamId + '</option>');
       });
       $('#fl-load-store-teams').hide();
@@ -349,12 +349,12 @@ function appStoreTeamSetup(devEmail, loadTeams) {
 }
 
 function loadEnterpriseData() {
-  $('#enterpriseConfiguration [name]').each(function(i, el) {
+  $('#enterpriseConfiguration [name]').each(function (i, el) {
     var name = $(el).attr("name");
 
     /* ADD BUNDLE ID */
     if (name === "fl-ent-bundleId" && typeof enterpriseSubmission.data[name] === "undefined") {
-      createBundleID(organizationName.toCamelCase(), appName.toCamelCase()).then(function(response) {
+      createBundleID(organizationName.toCamelCase(), appName.toCamelCase()).then(function (response) {
         if (response.resultCount === 0) {
           $('.bundleId-ent-text').html('com.' + organizationName.toCamelCase() + '.' + appName.toCamelCase());
           $('[name="' + name + '"]').val('com.' + organizationName.toCamelCase() + '.' + appName.toCamelCase());
@@ -467,12 +467,12 @@ function clearEnterpriseCredentials() {
 
 function loadEnterpriseTeams(devEmail) {
   return getTeams(enterpriseSubmission.id, false)
-    .then(function(teams) {
-      var enterpriseTeams = _.filter(teams, function(team) {
+    .then(function (teams) {
+      var enterpriseTeams = _.filter(teams, function (team) {
         return team.type === "In-House";
       })
       var options = ['<option value="">-- Select a team</option>'];
-      enterpriseTeams.forEach(function(team, i) {
+      enterpriseTeams.forEach(function (team, i) {
         options.push('<option value="' + team.teamId + '" data-team-name="' + team.name + '">'+ team.name +' - ' + team.teamId + '</option>');
       });
       $('#fl-load-ent-teams').hide();
@@ -511,12 +511,12 @@ function enterpriseTeamSetup(devEmail, loadTeams) {
 }
 
 function loadUnsignedData() {
-  $('#unsignedConfiguration [name]').each(function(i, el) {
+  $('#unsignedConfiguration [name]').each(function (i, el) {
     var name = $(el).attr("name");
 
     /* ADD BUNDLE ID */
     if (name === "fl-uns-bundleId" && typeof unsignedSubmission.data[name] === "undefined") {
-      createBundleID(organizationName.toCamelCase(), appName.toCamelCase()).then(function(response) {
+      createBundleID(organizationName.toCamelCase(), appName.toCamelCase()).then(function (response) {
         if (response.resultCount === 0) {
           $('.bundleId-uns-text').html('com.' + organizationName.toCamelCase() + '.' + appName.toCamelCase());
           $('[name="' + name + '"]').val('com.' + organizationName.toCamelCase() + '.' + appName.toCamelCase());
@@ -568,7 +568,7 @@ function loadUnsignedData() {
 
 
 function loadPushNotesData() {
-  $('#pushConfiguration [name]').each(function(i, el) {
+  $('#pushConfiguration [name]').each(function (i, el) {
     var name = $(el).attr("name");
 
     // ADDING NOTIFICATIONS SETTINGS
@@ -584,7 +584,7 @@ function loadPushNotesData() {
 }
 
 function submissionBuild(appSubmission, origin) {
-  Fliplet.App.Submissions.build(appSubmission.id).then(function(builtSubmission) {
+  Fliplet.App.Submissions.build(appSubmission.id).then(function (builtSubmission) {
 
     if (origin === "appStore") {
       appStoreSubmission = builtSubmission.submission;
@@ -631,7 +631,7 @@ function submissionBuild(appSubmission, origin) {
         Fliplet.Widget.autosize();
       });
     }, 10000);
-  }, function(err) {
+  }, function (err) {
     $('.button-' + origin + '-request').html('Request App <i class="fa fa-paper-plane"></i>');
     $('.button-' + origin + '-request').prop('disabled', false);
     Fliplet.Modal.alert({
@@ -643,8 +643,8 @@ function submissionBuild(appSubmission, origin) {
 function save(origin, submission) {
 
   Fliplet.App.Submissions.get()
-    .then(function(submissions) {
-      var savedSubmission = _.find(submissions, function(sub) {
+    .then(function (submissions) {
+      var savedSubmission = _.find(submissions, function (sub) {
         return sub.id === submission.id;
       });
 
@@ -663,7 +663,7 @@ function save(origin, submission) {
               previousResults: submission.result
             })
           })
-          .then(function(newSubmission) {
+          .then(function (newSubmission) {
             var cloneCredentialsPromise = Promise.resolve();
 
             if (origin === "appStore") {
@@ -700,7 +700,7 @@ function save(origin, submission) {
         }, 4000);
       });
     })
-    .catch(function(err) {
+    .catch(function (err) {
       Fliplet.Modal.alert({
         message: Fliplet.parseError(err)
       });
@@ -723,8 +723,8 @@ function requestBuild(origin, submission) {
   submission.data.legacyBuild = appSettings.legacyBuild || false;
 
   Fliplet.App.Submissions.get()
-    .then(function(submissions) {
-      var savedSubmission = _.find(submissions, function(sub) {
+    .then(function (submissions) {
+      var savedSubmission = _.find(submissions, function (sub) {
         return sub.id === submission.id;
       });
 
@@ -742,7 +742,7 @@ function requestBuild(origin, submission) {
               previousResults: submission.result
             })
           })
-          .then(function(newSubmission) {
+          .then(function (newSubmission) {
             if (origin === "appStore") {
               appStoreSubmission = newSubmission;
             }
@@ -918,7 +918,7 @@ function requestBuild(origin, submission) {
         submissionBuild(submission, origin);
       });
     })
-    .catch(function(err) {
+    .catch(function (err) {
       $('.button-' + origin + '-request').html('Request App <i class="fa fa-paper-plane"></i>');
       $('.button-' + origin + '-request').prop('disabled', false);
       Fliplet.Modal.alert({
@@ -931,7 +931,7 @@ function saveAppStoreData(request) {
   var data = appStoreSubmission.data;
   var pushData = notificationSettings;
 
-  $('#appStoreConfiguration [name]').each(function(i, el) {
+  $('#appStoreConfiguration [name]').each(function (i, el) {
     var name = $(el).attr("name");
     var value = $(el).val();
 
@@ -998,7 +998,7 @@ function saveEnterpriseData(request) {
   var pushData = notificationSettings;
   var uploadFilePromise = Promise.resolve();
 
-  $('#enterpriseConfiguration [name]').each(function(i, el) {
+  $('#enterpriseConfiguration [name]').each(function (i, el) {
     var name = $(el).attr("name");
     var value = $(el).val();
 
@@ -1062,7 +1062,7 @@ function saveEnterpriseData(request) {
       uploadFilePromise = Fliplet.Media.Files.upload({
         data: file,
         appId: Fliplet.Env.get('appId')
-      }).then(function(files) {
+      }).then(function (files) {
         data['fl-ent-certificate-files'] = files;
         return Promise.resolve();
       });
@@ -1100,7 +1100,7 @@ function saveEnterpriseData(request) {
 function saveUnsignedData(request) {
   var data = unsignedSubmission.data;
 
-  $('#unsignedConfiguration [name]').each(function(i, el) {
+  $('#unsignedConfiguration [name]').each(function (i, el) {
     var name = $(el).attr("name");
     var value = $(el).val();
 
@@ -1127,7 +1127,7 @@ function savePushData(silentSave) {
     'fl-push-keyId': 'apnKeyId'
   };
 
-  $('#pushConfiguration [name]').each(function(i, el) {
+  $('#pushConfiguration [name]').each(function (i, el) {
     var name = $(el).attr("name");
 
     if (!pushDataMap.hasOwnProperty(name)) {
@@ -1199,7 +1199,7 @@ function getTeams(id, isItunes) {
     method: 'GET',
     url: 'v1/organizations/' + organizationID + '/credentials/submission-' + id + '/teams?itunes=' + isItunes
   })
-  .then(function(result) {
+  .then(function (result) {
     return Promise.resolve(result.teams);
   });
 }
@@ -1210,7 +1210,7 @@ function searchCredentials(data) {
     url: 'v1/organizations/' + organizationID + '/credentials/search',
     data: data
   })
-  .then(function(credentials) {
+  .then(function (credentials) {
     return Promise.resolve(credentials);
   });
 }
@@ -1218,7 +1218,7 @@ function searchCredentials(data) {
 function getAppCredentials(credentialKey, teamId) {
   if (credentialKey) {
     return getCredential(credentialKey)
-      .then(function(credential) {
+      .then(function (credential) {
         if (credential && credential.teamId === teamId && (credential.p12 || credential.certificate)) {
           return credential;
         }
@@ -1251,7 +1251,7 @@ function refreshAppStoreOptions(devEmail, selectedTeamId, selectedTeamName) {
 
   return getAppCredentials(appStoreSubmission.data['fl-credentials'],
     selectedTeamId)
-    .then(function(credential) {
+    .then(function (credential) {
       if (credential) {
         return credential;
       }
@@ -1261,7 +1261,7 @@ function refreshAppStoreOptions(devEmail, selectedTeamId, selectedTeamName) {
         type: 'apple',
         teamId: selectedTeamId
       })
-      .then(function(response) {
+      .then(function (response) {
         var credentialKey;
         var submissionsWithCred = _.filter(Object.keys(response), function (o) {
           return response[o].hasCertificate === true;
@@ -1279,11 +1279,11 @@ function refreshAppStoreOptions(devEmail, selectedTeamId, selectedTeamName) {
 
         return;
       })
-      .catch(function(error) {
+      .catch(function (error) {
         return;
       });
     })
-    .then(function(credential) {
+    .then(function (credential) {
       if (credential) {
         return credential;
       }
@@ -1308,10 +1308,10 @@ function refreshAppStoreOptions(devEmail, selectedTeamId, selectedTeamName) {
 
       return getCompletedSubmissions(devEmail, selectedTeamId, selectedTeamName);
     })
-    .then(function(credential) {
+    .then(function (credential) {
       return setAppStorePrevCredentials(credential);
     })
-    .catch(function(error) {
+    .catch(function (error) {
       return setAppStorePrevCredentials();
     });
 }
@@ -1337,7 +1337,7 @@ function refreshAppEnterpriseOptions(devEmail, selectedTeamId, selectedTeamName)
 
   return getAppCredentials(enterpriseSubmission.data['fl-credentials'],
     selectedTeamId)
-    .then(function(credential) {
+    .then(function (credential) {
       if (credential) {
         return credential;
       }
@@ -1347,7 +1347,7 @@ function refreshAppEnterpriseOptions(devEmail, selectedTeamId, selectedTeamName)
         type: 'apple-enterprise',
         teamId: selectedTeamId
       })
-      .then(function(response) {
+      .then(function (response) {
         var credentialKey;
         var submissionsWithCred = _.filter(Object.keys(response), function (o) {
           return response[o].hasCertificate === true;
@@ -1365,11 +1365,11 @@ function refreshAppEnterpriseOptions(devEmail, selectedTeamId, selectedTeamName)
 
         return;
       })
-      .catch(function(error) {
+      .catch(function (error) {
         return;
       });
     })
-    .then(function(credential) {
+    .then(function (credential) {
       if (credential) {
         return credential;
       }
@@ -1394,10 +1394,10 @@ function refreshAppEnterpriseOptions(devEmail, selectedTeamId, selectedTeamName)
 
       return getCompletedSubmissions(devEmail, selectedTeamId, selectedTeamName);
     })
-    .then(function(credential) {
+    .then(function (credential) {
       return setAppEnterprisePrevCredential(credential);
     })
-    .catch(function(error) {
+    .catch(function (error) {
       return setAppEnterprisePrevCredential();
     });
 }
@@ -1414,7 +1414,7 @@ function getCompletedSubmissions(devEmail, teamId, teamName) {
     'failed',             // CI failed
     'cancelled'           // user canceled
   ];
-  var statusFilter = _.filter(statusList, function(s) {
+  var statusFilter = _.filter(statusList, function (s) {
     return s !== 'failed';
   });
   var url = [
@@ -1427,13 +1427,13 @@ function getCompletedSubmissions(devEmail, teamId, teamName) {
     method: 'GET',
     url: url
   })
-  .then(function(result) {
+  .then(function (result) {
     if (!result.submissions) {
       return;
     }
 
     var sortedSubmissions = _.orderBy(result.submissions, ['updatedAt'], ['desc']);
-    var latestSubmission = _.find(sortedSubmissions, function(sub) {
+    var latestSubmission = _.find(sortedSubmissions, function (sub) {
       return !_.isUndefined(sub.data.previousResults)
         && (!_.isUndefined(sub.data.previousResults.p12)
           || !_.isUndefined(sub.data.previousResults.certificate)
@@ -1460,7 +1460,7 @@ function getCredential(credentialKey) {
     method: 'GET',
     url: 'v1/organizations/' + organizationID + '/credentials/' + credentialKey
   })
-  .then(function(credential) {
+  .then(function (credential) {
     if (!credential || !credential.email) {
       // Valid credential email not found
       return Promise.resolve();
@@ -1487,7 +1487,7 @@ function createCertificates(options) {
       inHouse: options.inHouse
     }
   })
-  .then(function(credential) {
+  .then(function (credential) {
     return Promise.resolve(credential);
   });
 }
@@ -1510,8 +1510,8 @@ function revokeCertificate(id, certId) {
 }
 
 function init() {
-  Fliplet.Apps.get().then(function(apps) {
-    appInfo = _.find(apps, function(app) {
+  Fliplet.Apps.get().then(function (apps) {
+    appInfo = _.find(apps, function (app) {
       return app.id === Fliplet.Env.get('appId');
     });
   });
@@ -1541,11 +1541,11 @@ function init() {
 
 /* AUX FUNCTIONS */
 function checkGroupErrors() {
-  $('.has-error').each(function(i, el) {
+  $('.has-error').each(function (i, el) {
     $(el).parents('.panel-default').addClass('required-fill');
   });
 
-  $('.panel-default').each(function(i, el) {
+  $('.panel-default').each(function (i, el) {
     var withError = $(el).find('.has-error').length;
 
     if (withError === 0) {
@@ -1559,8 +1559,8 @@ function validateScreenshots() {
   var supportedFormats = [[1242,2208], [2048,2732], [2732,2048]];
   var allScreenShots = _.concat(screenShotsMobile, screenShotsTablet);
 
-  _.forEach(allScreenShots, function(screenshot, key) {
-    var supportedSize = _.find(supportedFormats, function(format) {
+  _.forEach(allScreenShots, function (screenshot, key) {
+    var supportedSize = _.find(supportedFormats, function (format) {
       return format[0] === screenshot.size[0] && format[1] === screenshot.size[1];
     });
 
@@ -1593,7 +1593,7 @@ function publishApp(context) {
     method: 'POST',
     url: 'v1/apps/' + Fliplet.Env.get('appId') + '/publish',
     data: options
-  }).then(function(response) {
+  }).then(function (response) {
     // Update appInfo
     appInfo.productionAppId = response.app.id;
 
@@ -1652,13 +1652,13 @@ function compileStatusTable(withData, origin, buildsData) {
 }
 
 function checkSubmissionStatus(origin, iosSubmissions) {
-  var submissionsToShow = _.filter(iosSubmissions, function(submission) {
+  var submissionsToShow = _.filter(iosSubmissions, function (submission) {
     return submission.status === "queued" || submission.status === "submitted" || submission.status === "processing" || submission.status === "completed" || submission.status === "failed" || submission.status === "cancelled" || submission.status === "ready-for-testing" || submission.status === "tested";
   });
 
   var buildsData = [];
   if (submissionsToShow.length) {
-    submissionsToShow.forEach(function(submission) {
+    submissionsToShow.forEach(function (submission) {
       var build = {};
       var appBuild;
       var debugHtmlPage;
@@ -1677,21 +1677,21 @@ function checkSubmissionStatus(origin, iosSubmissions) {
       }
 
       if (submission.result.appBuild && submission.result.appBuild.files) {
-        appBuild = _.find(submission.result.appBuild.files, function(file) {
+        appBuild = _.find(submission.result.appBuild.files, function (file) {
           return file.contentType === 'application/octet-stream';
         });
       } else if (submission.data.previousResults && submission.data.previousResults.appBuild && submission.data.previousResults.appBuild.files) {
-        appBuild = _.find(submission.data.previousResults.appBuild.files, function(file) {
+        appBuild = _.find(submission.data.previousResults.appBuild.files, function (file) {
           return file.contentType === 'application/octet-stream';
         });
       }
 
       if (submission.result.debugHtmlPage && submission.result.debugHtmlPage.files) {
-        debugHtmlPage = _.find(submission.result.debugHtmlPage.files, function(file) {
+        debugHtmlPage = _.find(submission.result.debugHtmlPage.files, function (file) {
           return file.contentType === 'text/html';
         });
       } else if (submission.data.previousResults && submission.data.previousResults.debugHtmlPage && submission.data.previousResults.debugHtmlPage.files) {
-        debugHtmlPage = _.find(submission.data.previousResults.debugHtmlPage.files, function(file) {
+        debugHtmlPage = _.find(submission.data.previousResults.debugHtmlPage.files, function (file) {
           return file.contentType === 'text/html';
         });
       }
@@ -1724,27 +1724,27 @@ function checkSubmissionStatus(origin, iosSubmissions) {
 }
 
 function submissionChecker(submissions) {
-  var asub = _.filter(submissions, function(submission) {
+  var asub = _.filter(submissions, function (submission) {
     return submission.data.submissionType === "appStore" && submission.platform === "ios";
   });
 
-  var completedAsub = _.filter(asub, function(submission) {
+  var completedAsub = _.filter(asub, function (submission) {
     return submission.status === "completed";
   });
 
   //Get the Submission data from the first completed submission, it has the certification values that are in use on the app store.
-  previousAppStoreSubmission = _.minBy(completedAsub, function(el) {
+  previousAppStoreSubmission = _.minBy(completedAsub, function (el) {
     return el.id;
   });
 
   appStoreSubmissionInStore = (completedAsub.length > 0);
 
-  asub = _.orderBy(asub, function(submission) {
+  asub = _.orderBy(asub, function (submission) {
     return new Date(submission.createdAt).getTime();
   }, ['desc']);
   checkSubmissionStatus("appStore", asub);
 
-  appStoreSubmission = _.maxBy(asub, function(el) {
+  appStoreSubmission = _.maxBy(asub, function (el) {
     return new Date(el.createdAt).getTime();
   });
 
@@ -1755,11 +1755,11 @@ function submissionChecker(submissions) {
   var cloneAppStoreCredentialsPromise = Promise.resolve();
   if (appStoreSubmission.data && !appStoreSubmission.data['fl-credentials']) {
 
-    var prevSubCred = _.filter(asub, function(submission) {
+    var prevSubCred = _.filter(asub, function (submission) {
       return submission.data && submission.data['fl-credentials'];
     });
 
-    var previousSubWithCredentials = _.maxBy(prevSubCred, function(el) {
+    var previousSubWithCredentials = _.maxBy(prevSubCred, function (el) {
       return new Date(el.createdAt).getTime();
     });
 
@@ -1770,24 +1770,24 @@ function submissionChecker(submissions) {
     }
   }
 
-  var esub = _.filter(submissions, function(submission) {
+  var esub = _.filter(submissions, function (submission) {
     return submission.data.submissionType === "enterprise" && submission.platform === "ios";
   });
 
-  var completedEsub = _.filter(esub, function(submission) {
+  var completedEsub = _.filter(esub, function (submission) {
     return submission.status === "completed";
   });
   //Get the Submission data from the first completed submission, it has certification values that are in use on the developer portal.
-  previousEnterpriseStoreSubmission = _.minBy(completedEsub, function(el) {
+  previousEnterpriseStoreSubmission = _.minBy(completedEsub, function (el) {
     return el.id;
   });
 
-  esub = _.orderBy(esub, function(submission) {
+  esub = _.orderBy(esub, function (submission) {
     return new Date(submission.createdAt).getTime();
   }, ['desc']);
   checkSubmissionStatus("enterprise", esub);
 
-  enterpriseSubmission = _.maxBy(esub, function(el) {
+  enterpriseSubmission = _.maxBy(esub, function (el) {
     return new Date(el.createdAt).getTime();
   });
 
@@ -1798,11 +1798,11 @@ function submissionChecker(submissions) {
   var cloneEnterpriseCredentialsPromise = Promise.resolve();
   if (enterpriseSubmission.data && !enterpriseSubmission.data['fl-credentials']) {
 
-    var prevSubCred = _.filter(esub, function(submission) {
+    var prevSubCred = _.filter(esub, function (submission) {
       return submission.data && submission.data['fl-credentials'];
     });
 
-    var previousSubWithCredentials = _.maxBy(prevSubCred, function(el) {
+    var previousSubWithCredentials = _.maxBy(prevSubCred, function (el) {
       return new Date(el.createdAt).getTime();
     });
 
@@ -1813,16 +1813,16 @@ function submissionChecker(submissions) {
     }
   }
 
-  var usub = _.filter(submissions, function(submission) {
+  var usub = _.filter(submissions, function (submission) {
     return submission.data.submissionType === "unsigned" && submission.platform === "ios";
   });
 
-  usub = _.orderBy(usub, function(submission) {
+  usub = _.orderBy(usub, function (submission) {
     return new Date(submission.createdAt).getTime();
   }, ['desc']);
   checkSubmissionStatus("unsigned", usub);
 
-  usub = _.maxBy(usub, function(el) {
+  usub = _.maxBy(usub, function (el) {
     return new Date(el.createdAt).getTime();
   });
   unsignedSubmission = usub;
@@ -1837,7 +1837,7 @@ function submissionChecker(submissions) {
           submissionType: "appStore"
         }
       })
-      .then(function(submission) {
+      .then(function (submission) {
         appStoreSubmission = submission;
         return Promise.resolve();
       });
@@ -1852,7 +1852,7 @@ function submissionChecker(submissions) {
           submissionType: "enterprise"
         }
       })
-      .then(function(submission) {
+      .then(function (submission) {
         enterpriseSubmission = submission;
         return Promise.resolve();
       });
@@ -1867,7 +1867,7 @@ function submissionChecker(submissions) {
           submissionType: "unsigned"
         }
       })
-      .then(function(submission) {
+      .then(function (submission) {
         unsignedSubmission = submission;
         return Promise.resolve();
       });
@@ -1878,26 +1878,26 @@ function submissionChecker(submissions) {
 }
 
 function iosSubmissionChecker(submissions) {
-  var asub = _.filter(submissions, function(submission) {
+  var asub = _.filter(submissions, function (submission) {
     return submission.data.submissionType === "appStore" && submission.platform === "ios";
   });
 
-  var esub = _.filter(submissions, function(submission) {
+  var esub = _.filter(submissions, function (submission) {
     return submission.data.submissionType === "enterprise" && submission.platform === "ios";
   });
 
-  var usub = _.filter(submissions, function(submission) {
+  var usub = _.filter(submissions, function (submission) {
     return submission.data.submissionType === "unsigned" && submission.platform === "ios";
   });
 
   // Ordering
-  asub = _.orderBy(asub, function(submission) {
+  asub = _.orderBy(asub, function (submission) {
     return new Date(submission.createdAt).getTime();
   }, ['desc']);
-  esub = _.orderBy(esub, function(submission) {
+  esub = _.orderBy(esub, function (submission) {
     return new Date(submission.createdAt).getTime();
   }, ['desc']);
-  usub = _.orderBy(usub, function(submission) {
+  usub = _.orderBy(usub, function (submission) {
     return new Date(submission.createdAt).getTime();
   }, ['desc']);
 
@@ -1914,14 +1914,14 @@ function initialLoad(initial, timeout) {
   if (!initial) {
     initLoad = setTimeout(function () {
       getSubmissions()
-        .then(function(submissions) {
+        .then(function (submissions) {
           iosSubmissionChecker(submissions);
           initialLoad(false, 15000);
         });
     }, timeout);
   } else {
     getSubmissions()
-      .then(function(submissions) {
+      .then(function (submissions) {
         if (!submissions.length) {
           return Promise.all([
             Fliplet.App.Submissions.create({
@@ -1930,7 +1930,7 @@ function initialLoad(initial, timeout) {
                 submissionType: "appStore"
               }
             })
-            .then(function(submission) {
+            .then(function (submission) {
               appStoreSubmission = submission;
             }),
             Fliplet.App.Submissions.create({
@@ -1939,7 +1939,7 @@ function initialLoad(initial, timeout) {
                 submissionType: "unsigned"
               }
             })
-            .then(function(submission) {
+            .then(function (submission) {
               unsignedSubmission = submission;
             }),
             Fliplet.App.Submissions.create({
@@ -1948,7 +1948,7 @@ function initialLoad(initial, timeout) {
                 submissionType: "enterprise"
               }
             })
-            .then(function(submission) {
+            .then(function (submission) {
               enterpriseSubmission = submission;
             })
           ]);
@@ -1958,7 +1958,7 @@ function initialLoad(initial, timeout) {
           cache: true,
           url: 'v1/user'
         })
-        .then(function(user) {
+        .then(function (user) {
           userInfo = user;
           return submissionChecker(submissions);
         });
@@ -1973,7 +1973,7 @@ function initialLoad(initial, timeout) {
             method: 'GET',
             url: 'v1/apps/' + Fliplet.Env.get('appId')
           })
-          .then(function(result) {
+          .then(function (result) {
             appName = result.app.name;
             appIcon = result.app.icon;
             appSettings = result.app.settings;
@@ -1982,7 +1982,7 @@ function initialLoad(initial, timeout) {
             method: 'GET',
             url: 'v1/organizations/' + organizationID
           })
-          .then(function(org) {
+          .then(function (org) {
             organizationName = org.name;
           })
         ]);
@@ -1991,13 +1991,13 @@ function initialLoad(initial, timeout) {
         if (appSettings.folderStructure) {
           var structure = [];
           hasFolders = true;
-          var appleOnly = _.filter(appSettings.folderStructure, function(obj) {
+          var appleOnly = _.filter(appSettings.folderStructure, function (obj) {
             return obj.platform === 'apple';
           });
 
-          return Promise.all(appleOnly.map(function(obj) {
+          return Promise.all(appleOnly.map(function (obj) {
             return Fliplet.Media.Folders.get({folderId: obj.folderId})
-              .then(function(result) {
+              .then(function (result) {
                 var tempObject = {
                   type: obj.type,
                   folderContent: result
@@ -2008,7 +2008,7 @@ function initialLoad(initial, timeout) {
               });
           }))
           .then(function () {
-            structure.forEach(function(el, idx) {
+            structure.forEach(function (el, idx) {
               if (el.type === 'mobile') {
                 screenShotsMobile = el.folderContent.files
               }
@@ -2028,7 +2028,7 @@ function initialLoad(initial, timeout) {
           url: 'v1/widget-instances/com.fliplet.push-notifications?appId=' + Fliplet.Env.get('appId')
         });
       })
-      .then(function(response) {
+      .then(function (response) {
         if (response.widgetInstance.settings && response.widgetInstance.settings) {
           notificationSettings = response.widgetInstance.settings;
         } else {
@@ -2115,11 +2115,11 @@ $('[name="fl-store-screenshots"]').on('change', function () {
     $('[data-item="fl-store-screenshots-existing"]').removeClass('show');
 
 
-    _.take(screenShotsMobile, 4).forEach(function(thumb) {
+    _.take(screenShotsMobile, 4).forEach(function (thumb) {
       $('.mobile-thumbs').append(addThumb(thumb));
     });
 
-    _.take(screenShotsTablet, 4).forEach(function(thumb) {
+    _.take(screenShotsTablet, 4).forEach(function (thumb) {
       $('.tablet-thumbs').append(addThumb(thumb));
     });
   }
@@ -2184,7 +2184,7 @@ $('a[data-toggle="tab"]')
     Fliplet.Widget.autosize();
   });
 
-$('[name="fl-store-keywords"]').on('tokenfield:createtoken', function(e) {
+$('[name="fl-store-keywords"]').on('tokenfield:createtoken', function (e) {
   var currentValue = e.currentTarget.value.replace(/,\s+/g, ',');
   var newValue = e.attrs.value;
   var oldAndNew = currentValue + ',' + newValue;
@@ -2194,7 +2194,7 @@ $('[name="fl-store-keywords"]').on('tokenfield:createtoken', function(e) {
   }
 });
 
-$('.redirectToSettings, [data-change-settings]').on('click', function(event) {
+$('.redirectToSettings, [data-change-settings]').on('click', function (event) {
   event.preventDefault();
 
   Fliplet.Studio.emit('close-overlay', {
@@ -2212,7 +2212,7 @@ $('.redirectToSettings, [data-change-settings]').on('click', function(event) {
   });
 });
 
-$('[data-change-assets]').on('click', function(event) {
+$('[data-change-assets]').on('click', function (event) {
   event.preventDefault();
 
   Fliplet.Studio.emit('close-overlay', {
@@ -2235,7 +2235,7 @@ $('#appStoreConfiguration, #enterpriseConfiguration, #unsignedConfiguration').on
   Fliplet.Widget.autosize();
 });
 
-$('#appStoreConfiguration').validator().on('submit', function(event) {
+$('#appStoreConfiguration').validator().on('submit', function (event) {
   if (_.includes(['fl-store-appDevLogin', 'fl-store-appDevPass'], document.activeElement.id)) {
     // User submitted app store login form
     $('.login-appStore-button').trigger('click');
@@ -2323,7 +2323,7 @@ $('#appStoreConfiguration').validator().on('submit', function(event) {
   setTimeout(checkGroupErrors, 0);
 });
 
-$('#enterpriseConfiguration').validator().on('submit', function(event) {
+$('#enterpriseConfiguration').validator().on('submit', function (event) {
   if (_.includes(['fl-ent-appDevLogin', 'fl-ent-appDevPass'], document.activeElement.id)) {
     // User submitted enterprise login form
     $('.login-enterprise-button').trigger('click');
@@ -2403,7 +2403,7 @@ $('#enterpriseConfiguration').validator().on('submit', function(event) {
   setTimeout(checkGroupErrors, 0);
 });
 
-$('#unsignedConfiguration').validator().on('submit', function(event) {
+$('#unsignedConfiguration').validator().on('submit', function (event) {
   if (event.isDefaultPrevented()) {
     // Gives time to Validator to apply classes
     setTimeout(checkGroupErrors, 0);
@@ -2511,7 +2511,7 @@ $('.login-appStore-button').on('click', function () {
         $this.removeClass('disabled');
         return appStoreTeamSetup(devEmail, true);
       })
-      .catch(function(error) {
+      .catch(function (error) {
         var message = 'Unable to log in';
 
         if (Fliplet.parseError(error)) {
@@ -2633,7 +2633,7 @@ $('.appStore-generate-cert').on('click', function () {
         organizationId: organizationID,
         submissionId: appStoreSubmission.id
       })
-        .then(function(response) {
+        .then(function (response) {
           var p12Url = Fliplet.Env.get('apiUrl') + 'v1/organizations/' + organizationID + '/credentials/submission-' + appStoreSubmission.id + '/download/p12'
           appStoreCertificateCreated = true;
           $('.appStore-generate-file-success').find('.appStore-file-name-success').html(response.certificate.name);
@@ -2645,7 +2645,7 @@ $('.appStore-generate-cert').on('click', function () {
           $this.removeClass('disabled');
         });
     })
-    .catch(function(error) {
+    .catch(function (error) {
       $this.html('Generate certificate');
       $this.removeClass('disabled');
       console.log(error);
@@ -2683,7 +2683,7 @@ $('.appStore-replace-cert').on('click', function () {
               organizationId: organizationID,
               submissionId: appStoreSubmission.id
             })
-              .then(function(response) {
+              .then(function (response) {
                 var p12Url = Fliplet.Env.get('apiUrl') + 'v1/organizations/' + organizationID + '/credentials/submission-' + appStoreSubmission.id + '/download/p12'
                 appStoreCertificateReplaced = true;
                 $('.appStore-previous-file-success').find('.appStore-file-name-success').html(response.certificate.name);
@@ -2695,7 +2695,7 @@ $('.appStore-replace-cert').on('click', function () {
               });
           });
       })
-      .catch(function(error) {
+      .catch(function (error) {
         $this.html('Replace certificate');
         $this.removeClass('disabled');
         console.log(error);
@@ -2755,7 +2755,7 @@ $('.login-enterprise-button').on('click', function () {
       $this.removeClass('disabled');
       return enterpriseTeamSetup(devEmail, true);
     })
-    .catch(function(error) {
+    .catch(function (error) {
       var message = 'Unable to log in';
 
       if (Fliplet.parseError(error)) {
@@ -2875,7 +2875,7 @@ $('.enterprise-generate-cert').on('click', function () {
         submissionId: enterpriseSubmission.id,
         inHouse: true
       })
-        .then(function(response) {
+        .then(function (response) {
           var p12Url = Fliplet.Env.get('apiUrl') + 'v1/organizations/' + organizationID + '/credentials/submission-' + enterpriseSubmission.id + '/download/p12'
           enterpriseCertificateCreated = true;
           $('.enterprise-generate-file-success').find('.enterprise-file-name-success').html(response.certificate.name);
@@ -2887,7 +2887,7 @@ $('.enterprise-generate-cert').on('click', function () {
           $this.removeClass('disabled');
         });
     })
-    .catch(function(error) {
+    .catch(function (error) {
       $this.html('Generate certificate');
       $this.removeClass('disabled');
       console.log(error);
@@ -2944,7 +2944,7 @@ $('.enterprise-replace-cert').on('click', function () {
               submissionId: enterpriseSubmission.id,
               inHouse: true
             })
-              .then(function(response) {
+              .then(function (response) {
                 var p12Url = Fliplet.Env.get('apiUrl') + 'v1/organizations/' + organizationID + '/credentials/submission-' + enterpriseSubmission.id + '/download/p12'
                 enterpriseCertificateReplaced = true;
                 $('.enterprise-previous-file-success').find('.enterprise-file-name-success').html(response.certificate.name);
@@ -2956,7 +2956,7 @@ $('.enterprise-replace-cert').on('click', function () {
               });
           });
       })
-      .catch(function(error) {
+      .catch(function (error) {
         $this.html('Replace certificate');
         $this.removeClass('disabled');
         console.log(error);
@@ -3013,7 +3013,7 @@ $(document).on('click', '[data-cancel-build-id]', function () {
   })
 });
 
-$('.browse-files').on('click', function(e) {
+$('.browse-files').on('click', function (e) {
   e.preventDefault();
 
   Fliplet.Studio.emit('overlay', {

--- a/js/interface.js
+++ b/js/interface.js
@@ -2019,18 +2019,6 @@ function prompt2FA() {
   });
 }
 
-function on2FASuccess(data) {
-  console.log('2FA success', data);
-}
-
-function on2FAFail(data) {
-  console.log('2FA fail', data);
-}
-
-function on2FACancel() {
-
-}
-
 /* ATTACH LISTENERS */
 $('[name="fl-store-screenshots"]').on('change', function() {
   var value = $(this).val();
@@ -2899,7 +2887,7 @@ socket.on('aab.apple.login.2fa', function (data) {
   // Ask user for code
   prompt2FA().then(function (code) {
     if (code === null) {
-      on2FACancel();
+      socket.to(data.clientId).emit('aab.apple.login.2fa.cancel');
       return;
     }
 
@@ -2910,16 +2898,10 @@ socket.on('aab.apple.login.2fa', function (data) {
 socket.on('aab.apple.login.2fa.devices', function (data) {
   select2FAMethod(data).then(function (selection) {
     if (selection === null) {
-      on2FACancel();
+      socket.to(data.clientId).emit('aab.apple.login.2fa.cancel');
       return;
     }
 
     socket.to(data.clientId).emit('aab.apple.login.2fa.device', selection);
   });
 });
-
-// Listen for a 2FA code successfully entered
-socket.on('aab.apple.login.2fa.success', on2FASuccess);
-
-// Listen for a wrong 2FA code
-socket.on('aab.apple.login.2fa.failure', on2FAFail);

--- a/js/interface.js
+++ b/js/interface.js
@@ -2860,3 +2860,13 @@ socket.on('aab.apple.login.2fa', function (data) {
     socket.to(data.clientId).emit('aab.apple.login.2fa.code', code);
   });
 });
+
+// Listen for a 2FA code successfully entered
+socket.on('aab.apple.login.2fa.success', function () {
+  console.log('2FA code is correct');
+});
+
+// Listen for a wrong 2FA code
+socket.on('aab.apple.login.2fa.failure', function () {
+  console.log('2FA code is wrong');
+});

--- a/js/interface.js
+++ b/js/interface.js
@@ -2851,7 +2851,7 @@ socket.on('aab.apple.login.2fa', function (data) {
   // Ask user for code
   prompt2FACode().then(function (code) {
     if (code === null) {
-      // @TODO Cancels login
+      socket.to(data.clientId).emit('aab.apple.login.2fa.cancel', code);
       return;
     }
 

--- a/js/interface.js
+++ b/js/interface.js
@@ -2383,18 +2383,18 @@ $('.login-appStore-button').on('click', function() {
       email: devEmail,
       password: devPass
     })
-    .then(function() {
-      return appStoreTeamSetup(devEmail, $this);
-    })
-    .catch(function(error) {
-      console.log(error);
-      if (error.responseJSON) {
-        $this.nextAll('.login-error').html(error.responseJSON.message);
-      }
-      $this.html('Log in');
-      $this.removeClass('disabled');
-      Fliplet.Widget.autosize();
-    });
+      .then(function() {
+        return appStoreTeamSetup(devEmail, $this);
+      })
+      .catch(function(error) {
+        console.log(error);
+        if (error.responseJSON) {
+          $this.nextAll('.login-error').html(error.responseJSON.message);
+        }
+        $this.html('Log in');
+        $this.removeClass('disabled');
+        Fliplet.Widget.autosize();
+      });
   }
 });
 

--- a/js/interface.js
+++ b/js/interface.js
@@ -688,13 +688,13 @@ function requestBuild(origin, submission) {
             // Check which type of certificate was given
             if (origin === "appStore" && appStoreSubmission.data['fl-store-distribution'] === 'previous-file' && appStorePreviousCredential) {
               return setCredentials(organizationID, appStoreSubmission.id, {
-                  teamId: appStorePreviousCredential.teamId,
-                  teamName: appStorePreviousCredential.teamName,
-                  certSigningRequest: appStorePreviousCredential.certSigningRequest,
-                  p12: appStorePreviousCredential.p12,
-                  certificate: appStorePreviousCredential.certificate,
-                  content: appStorePreviousCredential.content
-                })
+                teamId: appStorePreviousCredential.teamId,
+                teamName: appStorePreviousCredential.teamName,
+                certSigningRequest: appStorePreviousCredential.certSigningRequest,
+                p12: appStorePreviousCredential.p12,
+                certificate: appStorePreviousCredential.certificate,
+                content: appStorePreviousCredential.content
+              })
                 .then(function() {
                   submissionBuild(newSubmission, origin);
                 });
@@ -725,13 +725,13 @@ function requestBuild(origin, submission) {
 
             if (origin === "enterprise" && enterpriseSubmission.data['fl-ent-distribution'] === 'previous-file' && enterprisePreviousCredential) {
               return setCredentials(organizationID, enterpriseSubmission.id, {
-                  teamId: enterprisePreviousCredential.teamId,
-                  teamName: enterprisePreviousCredential.teamName,
-                  certSigningRequest: enterprisePreviousCredential.certSigningRequest,
-                  p12: enterprisePreviousCredential.p12,
-                  certificate: enterprisePreviousCredential.certificate,
-                  content: enterprisePreviousCredential.content
-                })
+                teamId: enterprisePreviousCredential.teamId,
+                teamName: enterprisePreviousCredential.teamName,
+                certSigningRequest: enterprisePreviousCredential.certSigningRequest,
+                p12: enterprisePreviousCredential.p12,
+                certificate: enterprisePreviousCredential.certificate,
+                content: enterprisePreviousCredential.content
+              })
                 .then(function() {
                   submissionBuild(newSubmission, origin);
                 });
@@ -750,9 +750,9 @@ function requestBuild(origin, submission) {
               var teamName = $('#fl-ent-teams').find(":selected").data('team-name');
 
               return setCredentials(organizationID, enterpriseSubmission.id, {
-                  teamId: teamId,
-                  teamName: teamName
-                })
+                teamId: teamId,
+                teamName: teamName
+              })
                 .then(function() {
                   return setCertificateP12(organizationID, enterpriseSubmission.id, formData)
                 })
@@ -775,13 +775,13 @@ function requestBuild(origin, submission) {
         // Check which type of certificate was given
         if (origin === "appStore" && appStoreSubmission.data['fl-store-distribution'] === 'previous-file' && appStorePreviousCredential) {
           return setCredentials(organizationID, appStoreSubmission.id, {
-              teamId: appStorePreviousCredential.teamId,
-              teamName: appStorePreviousCredential.teamName,
-              certSigningRequest: appStorePreviousCredential.certSigningRequest,
-              p12: appStorePreviousCredential.p12,
-              certificate: appStorePreviousCredential.certificate,
-              content: appStorePreviousCredential.content
-            })
+            teamId: appStorePreviousCredential.teamId,
+            teamName: appStorePreviousCredential.teamName,
+            certSigningRequest: appStorePreviousCredential.certSigningRequest,
+            p12: appStorePreviousCredential.p12,
+            certificate: appStorePreviousCredential.certificate,
+            content: appStorePreviousCredential.content
+          })
             .then(function() {
               submissionBuild(submission, origin);
             });
@@ -812,13 +812,13 @@ function requestBuild(origin, submission) {
 
         if (origin === "enterprise" && enterpriseSubmission.data['fl-ent-distribution'] === 'previous-file' && enterprisePreviousCredential) {
           return setCredentials(organizationID, enterpriseSubmission.id, {
-              teamId: enterprisePreviousCredential.teamId,
-              teamName: enterprisePreviousCredential.teamName,
-              certSigningRequest: enterprisePreviousCredential.certSigningRequest,
-              p12: enterprisePreviousCredential.p12,
-              certificate: enterprisePreviousCredential.certificate,
-              content: enterprisePreviousCredential.content
-            })
+            teamId: enterprisePreviousCredential.teamId,
+            teamName: enterprisePreviousCredential.teamName,
+            certSigningRequest: enterprisePreviousCredential.certSigningRequest,
+            p12: enterprisePreviousCredential.p12,
+            certificate: enterprisePreviousCredential.certificate,
+            content: enterprisePreviousCredential.content
+          })
             .then(function() {
               submissionBuild(submission, origin);
             });
@@ -2790,9 +2790,9 @@ $('.enterprise-replace-cert').on('click', function() {
     return revokeCertificate(organizationID, enterpriseSubmission.id, enterprisePreviousCredential.certificate.id)
       .then(function() {
         return setCredentials(organizationID, enterpriseSubmission.id, {
-            teamId: teamId,
-            teamName: teamName
-          })
+          teamId: teamId,
+          teamName: teamName
+        })
           .then(function() {
             return createCertificates({
               organiazationId: organizationID,

--- a/js/interface.js
+++ b/js/interface.js
@@ -242,7 +242,7 @@ function loadAppStoreData() {
   if (appStoreSubmission.data && appStoreSubmission.data['fl-credentials']) {
     // Submission data contains credential key
     var $loginButton = $('.login-appStore-button');
-    $loginButton.html('Logging in' + spinner);
+    $loginButton.html('Logging in ' + spinner);
     $loginButton.addClass('disabled');
     $('#fl-store-appDevPass').addClass('disabled');
     $('#fl-store-appDevLogin').addClass('disabled');
@@ -421,7 +421,7 @@ function loadEnterpriseData() {
   if (enterpriseSubmission.data && enterpriseSubmission.data['fl-credentials']) {
     // Submission data contains credential key
     var $loginButton = $('.login-enterprise-button');
-    $loginButton.html('Logging in' + spinner);
+    $loginButton.html('Logging in ' + spinner);
     $loginButton.addClass('disabled');
     $('#fl-ent-appDevLogin').addClass('disabled');
     $('#fl-ent-appDevPass').addClass('disabled');
@@ -710,7 +710,7 @@ function save(origin, submission) {
 }
 
 function requestBuild(origin, submission) {
-  $('.button-' + origin + '-request').html('Requesting' + spinner);
+  $('.button-' + origin + '-request').html('Requesting ' + spinner);
 
   if (origin === 'appStore') {
     submission.data.folderStructure = appSettings.folderStructure;
@@ -2110,6 +2110,7 @@ $('[name="fl-store-screenshots"]').on('change', function () {
     $('[data-item="fl-store-screenshots-new"]').removeClass('show');
     $('[data-item="fl-store-screenshots-existing"]').removeClass('show');
   }
+
   if (value === 'new' && haveScreenshots) {
     $('[data-item="fl-store-screenshots-new-warning"]').removeClass('show');
     $('[data-item="fl-store-screenshots-new"]').addClass('show');
@@ -2125,6 +2126,7 @@ $('[name="fl-store-screenshots"]').on('change', function () {
       $('.tablet-thumbs').append(addThumb(thumb));
     });
   }
+
   if (value === 'existing') {
     $('.app-details-appStore .app-screenshots').removeClass('has-error');
     $('[data-item="fl-store-screenshots-existing"]').addClass('show');
@@ -2312,7 +2314,7 @@ $('#appStoreConfiguration').validator().on('submit', function (event) {
     }
   } else {
     var initialHtml = $('.button-appStore-request').html();
-    $('.button-appStore-request').html('Please wait' + spinner);
+    $('.button-appStore-request').html('Please wait ' + spinner);
     $('.button-appStore-request').prop('disabled', true);
 
     publishApp('appStore').catch(function () {
@@ -2392,7 +2394,7 @@ $('#enterpriseConfiguration').validator().on('submit', function (event) {
     }
   } else {
     var initialHtml = $('.button-enterprise-request').html();
-    $('.button-enterprise-request').html('Please wait' + spinner);
+    $('.button-enterprise-request').html('Please wait ' + spinner);
     $('.button-enterprise-request').prop('disabled', true);
 
     publishApp('enterprise').catch(function () {
@@ -2441,7 +2443,7 @@ $('#unsignedConfiguration').validator().on('submit', function (event) {
     }
   } else {
     var initialHtml = $('.button-unsigned-request').html();
-    $('.button-unsigned-request').html('Please wait' + spinner);
+    $('.button-unsigned-request').html('Please wait ' + spinner);
     $('.button-unsigned-request').prop('disabled', true);
 
     publishApp('unsigned').catch(function () {
@@ -2471,7 +2473,7 @@ $('[data-push-save]').on('click', function () {
 /* Credentials and Certificates App Store */
 $('.login-appStore-button').on('click', function () {
   var $this = $(this);
-  $(this).html('Logging in' + spinner);
+  $(this).html('Logging in ' + spinner);
   $(this).addClass('disabled');
   var devEmail = $('#fl-store-appDevLogin').val();
   var devPass = $('#fl-store-appDevPass').val();
@@ -2576,7 +2578,7 @@ $('#fl-load-store-teams').on('click', function (e) {
   e.preventDefault();
   var $button = $(this);
   var initialLabel = $button.html();
-  $button.html('Loading' + spinner).addClass('disabled');
+  $button.html('Loading ' + spinner).addClass('disabled');
   loadAppStoreTeams($('.appStore-logged-email').text())
     .then(function () {
       $button.html(initialLabel).removeClass('disabled');
@@ -2621,7 +2623,7 @@ $('#fl-store-teams').on('change', function () {
 
 $('.appStore-generate-cert').on('click', function () {
   var $this = $(this);
-  $(this).html('Generating' + spinner);
+  $(this).html('Generating ' + spinner);
   $(this).addClass('disabled');
   $('.generate-error').html(''); // Cleans errors
   var teamId = $('#fl-store-teams').val();
@@ -2668,7 +2670,7 @@ $('#fl-store-certificate').on('change', function () {
 
 $('.appStore-replace-cert').on('click', function () {
   var $this = $(this);
-  $(this).html('Replacing' + spinner);
+  $(this).html('Replacing ' + spinner);
   $(this).addClass('disabled');
   $('.replace-error').html(''); // Cleans errors
   var teamId = appStorePreviousCredential ? appStorePreviousCredential.teamId : '';
@@ -2716,7 +2718,7 @@ $('.appStore-replace-cert').on('click', function () {
 /* Credentials and Certificates Enterprise */
 $('.login-enterprise-button').on('click', function () {
   var $this = $(this);
-  $(this).html('Logging in' + spinner);
+  $(this).html('Logging in ' + spinner);
   $(this).addClass('disabled');
   var devEmail = $('#fl-ent-appDevLogin').val();
   var devPass = $('#fl-ent-appDevPass').val();
@@ -2819,7 +2821,7 @@ $('#fl-load-ent-teams').on('click', function (e) {
   e.preventDefault();
   var $button = $(this);
   var initialLabel = $button.html();
-  $button.html('Loading' + spinner).addClass('disabled');
+  $button.html('Loading ' + spinner).addClass('disabled');
   loadEnterpriseTeams($('.enterprise-logged-email').text())
     .then(function () {
       $button.html(initialLabel).removeClass('disabled');
@@ -2864,7 +2866,7 @@ $('#fl-ent-teams').on('change', function () {
 
 $('.enterprise-generate-cert').on('click', function () {
   var $this = $(this);
-  $(this).html('Generating' + spinner);
+  $(this).html('Generating ' + spinner);
   $(this).addClass('disabled');
   $('.generate-error').html(''); // Cleans errors
   var teamId = $('#fl-ent-teams').val();
@@ -2930,7 +2932,7 @@ $('#fl-ent-mobileprovision-manual-details').on('change', function () {
 
 $('.enterprise-replace-cert').on('click', function () {
   var $this = $(this);
-  $(this).html('Replacing' + spinner);
+  $(this).html('Replacing ' + spinner);
   $(this).addClass('disabled');
   $('.replace-error').html(''); // Cleans errors
   var teamId = enterprisePreviousCredential ? enterprisePreviousCredential.teamId : '';

--- a/js/interface.js
+++ b/js/interface.js
@@ -1989,7 +1989,7 @@ function select2FAMethod(data) {
 
     if (selection === '') {
       return Fliplet.Modal.alert({
-        message: 'You must select a device to continue.'
+        message: 'You must choose a device to continue.'
       }).then(function () {
         return select2FAMethod(data);
       });

--- a/js/interface.js
+++ b/js/interface.js
@@ -1407,6 +1407,7 @@ function getCredential(credentialKey) {
   })
   .then(function(credential) {
     if (!credential || !credential.email) {
+      // Valid credential email not found
       return Promise.resolve();
     }
 
@@ -1414,6 +1415,7 @@ function getCredential(credentialKey) {
   })
   .catch(function (error) {
     if (error && error.status === 404) {
+      // Credential not found
       return Promise.resolve();
     }
 

--- a/js/interface.js
+++ b/js/interface.js
@@ -2006,7 +2006,7 @@ function select2FADevice(data) {
 
 function prompt2FA() {
   return Fliplet.Modal.prompt({
-    title: 'A message with a verification code has been sent to your devices. Please enter the code to continue.<div class="alert alert-info alert-sm"><strong>Note:</strong> If you are not certain which devices to check, please contact your Apple account administrator or IT team.</div>',
+    title: 'Apple has sent a verification code to your devices. Please enter the code to continue.<div class="alert alert-info alert-sm"><strong>Note:</strong> If you don\'t receive the code, please check your Apple account settings.</div>',
     size: 'small'
   }).then(function (code) {
     if (code === null) {

--- a/js/interface.js
+++ b/js/interface.js
@@ -2905,7 +2905,7 @@ $('[name="submissionType"][value="appStore"]').prop('checked', true).trigger('ch
 initLoad = initialLoad(true, 0);
 
 // Listen for 2FA code when requested
-socket.on('aab.apple.login.2fa', function () {
+socket.on('aab.apple.login.2fa', function (data) {
   // Ask user for code
   prompt2FA().then(function (code) {
     if (code === null) {

--- a/js/interface.js
+++ b/js/interface.js
@@ -2856,7 +2856,7 @@ socket.on('aab.apple.login.2fa', function (data) {
     }
 
     // Notify requester with the code
-    // @Question What happens when 2FA fails?
+    // @Question What happens when 2FA succeeds/fails?
     socket.to(data.clientId).emit('aab.apple.login.2fa.code', code);
   });
 });

--- a/js/interface.js
+++ b/js/interface.js
@@ -279,13 +279,14 @@ function clearAppStoreCredentials() {
     email: null,
     password: null,
     teamId: null
-  }, false).then(function () {
-    appStoreLoggedIn = false;
-    $('#fl-store-appDevPass').prop('required', true);
-    $('.appStore-logged-email').html('');
-    $('.appStore-login-details').removeClass('hidden');
-    $('.appStore-logged-in, .appStore-more-options, .appStore-teams').removeClass('show');
-  });
+  }, false)
+    .then(function () {
+      appStoreLoggedIn = false;
+      $('#fl-store-appDevPass').prop('required', true);
+      $('.appStore-logged-email').html('');
+      $('.appStore-login-details').removeClass('hidden');
+      $('.appStore-logged-in, .appStore-more-options, .appStore-teams').removeClass('show');
+    });
 }
 
 function loadAppStoreTeams(devEmail) {
@@ -456,13 +457,14 @@ function clearEnterpriseCredentials() {
     email: null,
     password: null,
     teamId: null
-  }, false).then(function () {
-    enterpriseLoggedIn = false;
-    $('#fl-ent-appDevPass').prop('required', true);
-    $('.enterprise-logged-email').html('');
-    $('.enterprise-login-details').removeClass('hidden');
-    $('.enterprise-logged-in, .enterprise-more-options, .enterprise-teams').removeClass('show');
-  });
+  }, false)
+    .then(function () {
+      enterpriseLoggedIn = false;
+      $('#fl-ent-appDevPass').prop('required', true);
+      $('.enterprise-logged-email').html('');
+      $('.enterprise-login-details').removeClass('hidden');
+      $('.enterprise-logged-in, .enterprise-more-options, .enterprise-teams').removeClass('show');
+    });
 }
 
 function loadEnterpriseTeams(devEmail) {
@@ -2507,9 +2509,11 @@ $('.login-appStore-button').on('click', function () {
       password: devPass
     })
       .then(function () {
+        return appStoreTeamSetup(devEmail, true);
+      })
+      .then(function () {
         $this.html('Log in');
         $this.removeClass('disabled');
-        return appStoreTeamSetup(devEmail, true);
       })
       .catch(function (error) {
         var message = 'Unable to log in';
@@ -2750,10 +2754,12 @@ $('.login-enterprise-button').on('click', function () {
       password: devPass
     })
     .then(function () {
+      return enterpriseTeamSetup(devEmail, true);
+    })
+    .then(function () {
       $('[name="fl-ent-distribution"][value="generate-file"]').prop('checked', true).trigger('change');
       $this.html('Log in');
       $this.removeClass('disabled');
-      return enterpriseTeamSetup(devEmail, true);
     })
     .catch(function (error) {
       var message = 'Unable to log in';

--- a/js/interface.js
+++ b/js/interface.js
@@ -1979,7 +1979,7 @@ function select2FAMethod(data) {
   });
 
   return Fliplet.Modal.prompt({
-    title: 'Please select a device to verify your identity',
+    title: 'Your Apple ID is protected with two-step verification. Choose a trusted device to receive a verification code.',
     inputType: 'select',
     inputOptions: options
   }).then(function (selection) {
@@ -1989,7 +1989,7 @@ function select2FAMethod(data) {
 
     if (selection === '') {
       return Fliplet.Modal.alert({
-        message: 'You must select a device to verify your identity'
+        message: 'You must select a device to continue.'
       }).then(function () {
         return select2FAMethod(data);
       });
@@ -1999,9 +1999,9 @@ function select2FAMethod(data) {
   });
 }
 
-function prompt2FA() {
+function prompt2FA(data) {
   return Fliplet.Modal.prompt({
-    title: 'Please enter the verification code to verify your login'
+    title: 'A message with a verification code has been sent to your devices. Please enter the code to continue.'
   }).then(function (code) {
     if (code === null) {
       return null;
@@ -2009,9 +2009,9 @@ function prompt2FA() {
 
     if (code === '') {
       return Fliplet.Modal.alert({
-        message: 'You must enter the verification code to log in'
+        message: 'You must enter the verification code to continue.'
       }).then(function () {
-        return prompt2FA();
+        return prompt2FA(data);
       });
     }
 
@@ -2885,7 +2885,7 @@ initLoad = initialLoad(true, 0);
 // Listen for 2FA code when requested
 socket.on('aab.apple.login.2fa', function (data) {
   // Ask user for code
-  prompt2FA().then(function (code) {
+  prompt2FA(data).then(function (code) {
     if (code === null) {
       socket.to(data.clientId).emit('aab.apple.login.2fa.cancel');
       return;

--- a/js/interface.js
+++ b/js/interface.js
@@ -2430,9 +2430,7 @@ $('.login-appStore-button').on('click', function() {
       })
       .catch(function(error) {
         console.log(error);
-        if (error.responseJSON) {
-          $this.nextAll('.login-error').html(error.responseJSON.message);
-        }
+        $this.nextAll('.login-error').html(Fliplet.parseError(error));
         $this.html('Log in');
         $this.removeClass('disabled');
         Fliplet.Widget.autosize();
@@ -2537,9 +2535,8 @@ $('.appStore-generate-cert').on('click', function() {
     .catch(function(error) {
       $this.html('Generate certificate');
       $this.removeClass('disabled');
-      if (error.responseJSON.message) {
-        $('.generate-error').html(error.responseJSON.message);
-      }
+      console.log(error);
+      $('.generate-error').html(Fliplet.parseError(error));
     });
 });
 
@@ -2588,9 +2585,8 @@ $('.appStore-replace-cert').on('click', function() {
       .catch(function(error) {
         $this.html('Replace certificate');
         $this.removeClass('disabled');
-        if (error.responseJSON.message) {
-          $('.replace-error').html(error.responseJSON.message);
-        }
+        console.log(error);
+        $('.replace-error').html(Fliplet.parseError(error));
       });
     } else {
       $this.html('Replace certificate');
@@ -2645,9 +2641,8 @@ $('.login-enterprise-button').on('click', function() {
       return enterpriseTeamSetup(devEmail, $this);
     })
     .catch(function(error) {
-      if (error.responseJSON) {
-        $this.nextAll('.login-error').html(error.responseJSON.message);
-      }
+      console.log(error);
+      $this.nextAll('.login-error').html(Fliplet.parseError(error));
       $this.html('Log in');
       $this.removeClass('disabled');
       Fliplet.Widget.autosize();
@@ -2750,9 +2745,8 @@ $('.enterprise-generate-cert').on('click', function() {
     .catch(function(error) {
       $this.html('Generate certificate');
       $this.removeClass('disabled');
-      if (error.responseJSON.message) {
-        $('.generate-error').html(error.responseJSON.message);
-      }
+      console.log(error);
+      $('.generate-error').html(Fliplet.parseError(error));
     });
 });
 
@@ -2820,9 +2814,8 @@ $('.enterprise-replace-cert').on('click', function() {
       .catch(function(error) {
         $this.html('Replace certificate');
         $this.removeClass('disabled');
-        if (error.responseJSON.message) {
-          $('.replace-error').html(error.responseJSON.message);
-        }
+        console.log(error);
+        $('.replace-error').html(Fliplet.parseError(error));
       });
   } else {
     $this.html('Replace certificate');

--- a/js/interface.js
+++ b/js/interface.js
@@ -1990,7 +1990,7 @@ function select2FAMethod(data) {
       return Fliplet.Modal.alert({
         message: 'You must select a device to verify your identity'
       }).then(function () {
-        return select2FAMethod();
+        return select2FAMethod(data);
       });
     }
 

--- a/js/interface.templates.js
+++ b/js/interface.templates.js
@@ -5,7 +5,7 @@ this["Fliplet"]["Widget"]["Templates"] = this["Fliplet"]["Widget"]["Templates"] 
 this["Fliplet"]["Widget"]["Templates"]["templates.thumbs"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
     var helper;
 
-  return "<div class=\"col-xs-3\">\r\n  <img src=\""
+  return "<div class=\"col-xs-3\">\n  <img src=\""
     + container.escapeExpression(((helper = (helper = helpers.url || (depth0 != null ? depth0.url : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"url","hash":{},"data":data}) : helper)))
-    + "\"/>\r\n</div>";
+    + "\"/>\n</div>";
 },"useData":true});

--- a/widget.json
+++ b/widget.json
@@ -12,6 +12,7 @@
       "lodash",
       "fliplet-app-submissions",
       "fliplet-media",
+      "fliplet-socket",
       "fliplet-studio-ui",
       "handlebars",
       "bootstrap",


### PR DESCRIPTION
### Login flow

![image](https://user-images.githubusercontent.com/290733/53259657-84728400-36c7-11e9-8b11-d72c2701bd88.png)

### Load teams

Teams will no longer be automatically loaded when you open the AAB UI. This is because 2FA might be required, and if it's automated process, users will be unexpectedly asked to enter 2FA code.

They don't need to enter login details again, though. We've simply added a **Load teams** button, which will load the teams on demand -- and might require 2FA verification using the UI above if necessary.

![image](https://user-images.githubusercontent.com/290733/53256424-c26baa00-36bf-11e9-825c-8f8719b38786.png)
