### PR TITLE
Copy update for 2FA prompt

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -2077,7 +2077,7 @@ function select2FADevice(data) {
 
 function prompt2FA() {
   return Fliplet.Modal.prompt({
-    title: 'Apple has sent a verification code to your devices. Please enter the code to continue.<div class="alert alert-info alert-sm"><strong>Note:</strong> If you don\'t receive the code, please check your Apple account settings.</div>',
+    title: 'Apple has sent a verification code to your devices from one of Fliplet\'s server locations. Please enter the code to continue.<div class="alert alert-info alert-sm"><strong>Note:</strong> If you don\'t receive the code, please check your Apple account settings.</div>',
     size: 'small'
   }).then(function (code) {
     if (code === null) {

--- a/js/interface.js
+++ b/js/interface.js
@@ -2076,14 +2076,20 @@ function select2FADevice(data) {
 }
 
 function prompt2FA() {
-  var region = Fliplet.Env.get('user').auth_token.substr(0, 2);
+  var region = Fliplet.User.getAuthToken().substr(0, 2);
   var serverLocations = {
     eu: 'Dublin, Ireland',
     us: 'San Francisco, US'
   };
 
   return Fliplet.Modal.prompt({
-    title: 'Apple has sent a verification code to your devices from <strong>' + serverLocations[region] + '</strong>. Please enter the code to continue.<div class="alert alert-info alert-sm"><strong>Note:</strong> If you don\'t receive the code, please check your Apple account settings.</div>',
+    title: [
+      'Apple has sent a verification code to your devices from ',
+      serverLocations[region]
+        ? '<strong>' + serverLocations[region] + '</strong>'
+        : 'one of Fliplet\'s server locations',
+      '. Please enter the code to continue.<div class="alert alert-info alert-sm"><strong>Note:</strong> If you don\'t receive the code, please check your Apple account settings.</div>'
+    ].join(''),
     size: 'small'
   }).then(function (code) {
     if (code === null) {

--- a/js/interface.js
+++ b/js/interface.js
@@ -2076,8 +2076,14 @@ function select2FADevice(data) {
 }
 
 function prompt2FA() {
+  var region = Fliplet.Env.get('user').auth_token.substr(0, 2);
+  var serverLocations = {
+    eu: 'Dublin, Ireland',
+    us: 'San Francisco, California'
+  };
+
   return Fliplet.Modal.prompt({
-    title: 'Apple has sent a verification code to your devices from one of Fliplet\'s server locations. Please enter the code to continue.<div class="alert alert-info alert-sm"><strong>Note:</strong> If you don\'t receive the code, please check your Apple account settings.</div>',
+    title: 'Apple has sent a verification code to your devices from <strong>' + serverLocations[region] + '</strong>. Please enter the code to continue.<div class="alert alert-info alert-sm"><strong>Note:</strong> If you don\'t receive the code, please check your Apple account settings.</div>',
     size: 'small'
   }).then(function (code) {
     if (code === null) {

--- a/js/interface.js
+++ b/js/interface.js
@@ -2079,7 +2079,7 @@ function prompt2FA() {
   var region = Fliplet.Env.get('user').auth_token.substr(0, 2);
   var serverLocations = {
     eu: 'Dublin, Ireland',
-    us: 'San Francisco, California'
+    us: 'San Francisco, US'
   };
 
   return Fliplet.Modal.prompt({


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/3261

2FA requests are sent from Fliplet's server, which wouldn't be the same as the user's browser location.

To avoid confusion, the prompt copy is updated to, "Apple has sent a verification code to your devices from **(location based on user authentication token prefix)**"

![screenshot 2019-02-25 at 12 09 27](https://user-images.githubusercontent.com/290733/53340286-8a9f7500-3900-11e9-8304-4ee28e40eaf1.png)

![image](https://user-images.githubusercontent.com/290733/53340792-bff89280-3901-11e9-8b5a-9c43edcf2cf5.png)
