### PR TITLE
Adds UI for entering app-specific password

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -62,6 +62,10 @@
   padding-top: 4px;
 }
 
+.bs-actionsbox .btn-group button {
+  margin-top: 0;
+}
+
 /*@media (min-width: 640px) {
   .form-horizontal .control-label {
     padding-top: 12px;

--- a/interface.html
+++ b/interface.html
@@ -671,6 +671,19 @@
                   </div>
                 </div>
 
+                <h3><small>App-specific password</small></h3>
+                <div class="form-group clearfix">
+                  <div class="col-sm-4 control-label">
+                    <label for="fl-store-versionNumber">App-specific password</label>
+                    <p class="help-block label-helper"><small><strong>If your Apple account has two-step verification enabled</strong>, this is needed to ensure Fliplet is authorized to submit your app to the store.</small></p>
+                  </div>
+                  <div class="col-sm-8">
+                    <input type="text" name="fl-store-appPassword" class="form-control" id="fl-store-appPassword" data-error="Please enter an app-specific password" maxlength="19" />
+                    <div class="help-block with-errors"></div>
+                    <p class="help-block"><small>See <a href="https://support.apple.com/en-gb/HT204397" target="_blank">Apple documentation</a> to learn more about app-specific passwords and how to create them.</small></p>
+                  </div>
+                </div>
+
                 <h3><small>App version and bundle ID</small></h3>
                 <div class="form-group clearfix">
                   <div class="col-sm-4 control-label">


### PR DESCRIPTION
App-specific password is saved in organisation credentials as `crendential.appPassword`.

![image](https://user-images.githubusercontent.com/290733/53650069-94e0ac80-3c3b-11e9-938f-f6f804fc2af7.png)

### Tested

- [x] App-specific password is saved in credentials when saving submissions
- [x] App-specific password is not saved in app submission data when saving submissions
- [x] App-specific password is saved in credentials when requesting submissions
- [x]  App-specific password is not saved in app submission data when requesting submissions