### PR TITLE
Refactored to support 2FA within the AAB UI

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -6,6 +6,10 @@
   opacity: 0.3;
 }
 
+.appStore-login-2fa-devices,
+.appStore-login-2fa-waiting,
+.appStore-login-2fa-code,
+.appStore-2fa-sms,
 .appStore-logged-in,
 .appStore-teams,
 .appStore-more-options,
@@ -14,6 +18,10 @@
 .appStore-generate-file,
 .appStore-generate-file-success,
 .appStore-upload-file,
+.enterprise-login-2fa-devices,
+.enterprise-login-2fa-waiting,
+.enterprise-login-2fa-code,
+.enterprise-2fa-sms,
 .enterprise-manual-details,
 .enterprise-logged-in,
 .enterprise-teams,
@@ -136,15 +144,31 @@
   margin: 0;
 }
 
-.nav-tabs>li>a span {
+.nav-tabs > li > a span {
   display: block;
   text-align: center;
 }
 
-.nav-tabs>li>a span:first-child {
+.nav-tabs > li > a span:first-child {
   font-weight: bold;
 }
 
+.btn-group-vertical .btn input[type="radio"] {
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  -webkit-appearance: none;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  cursor: pointer;
+}
+
+.btn-group-vertical .btn {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 
 /* End Override */
 
@@ -155,7 +179,7 @@ h3 {
   color: #14505E;
 }
 
-body>h3,
+body > h3,
 .app-status h3 {
   margin-top: 0;
 }
@@ -238,9 +262,9 @@ h3 small {
 .bootstrap-select .btn-default:active:focus,
 .bootstrap-select .btn-default:active,
 .bootstrap-select .btn-default:focus,
-.open>.dropdown-toggle.btn-default,
-.open>.dropdown-toggle.btn-default:focus,
-.open>.dropdown-toggle.btn-default:hover {
+.open > .dropdown-toggle.btn-default,
+.open > .dropdown-toggle.btn-default:focus,
+.open > .dropdown-toggle.btn-default:hover {
   background-color: transparent;
   outline: none !important;
   border-color: #00abd1;

--- a/interface.html
+++ b/interface.html
@@ -559,7 +559,7 @@
                       <label for="fl-store-appDevLogin">Apple Developer account login</label>
                     </div>
                     <div class="col-sm-8">
-                      <input type="email" class="form-control" id="fl-store-appDevLogin" data-error="Please enter a valid email address">
+                      <input type="email" class="form-control" id="fl-store-appDevLogin" data-error="Please enter a valid email address" required>
                       <div class="help-block with-errors"></div>
                     </div>
                   </div>
@@ -590,7 +590,7 @@
                     </div>
                     <div class="col-sm-8">
                       <div class="form-control-static">
-                        <span class="appStore-logged-email"></span> - <a href="#" class="log-out-appStore">log out</a>
+                        <span class="appStore-logged-email"></span> - <a href="#" class="log-out-appStore">Change account</a>
                       </div>
                     </div>
                   </div>
@@ -1261,7 +1261,7 @@ If you have any questions please reply and I will be happy to answer any questio
                     </div>
                     <div class="col-sm-8">
                       <div class="form-control-static">
-                        <span class="enterprise-logged-email"></span> - <a href="#" class="log-out-enterprise">log out</a>
+                        <span class="enterprise-logged-email"></span> - <a href="#" class="log-out-enterprise">Change account</a>
                       </div>
                     </div>
                   </div>

--- a/interface.html
+++ b/interface.html
@@ -523,7 +523,7 @@
                   <div class="col-sm-8">
                     <input type="text" name="fl-store-copyright" class="form-control" id="fl-store-copyright" maxlength="200" data-error="Please enter your Copyright text" required />
                     <div class="help-block with-errors"></div>
-                    <p class="help-block"><small>Eg: 2008 Acme Inc.</small></p>
+                    <p class="help-block"><small>e.g. 2008 Acme Inc.</small></p>
                   </div>
                 </div>
                 <div class="form-group clearfix">
@@ -580,6 +580,43 @@
                     <div class="col-sm-8">
                       <button type="button" class="btn btn-primary login-appStore-button">Log in</button>
                       <div class="text-danger login-error"></div>
+                    </div>
+                  </div>
+                </div>
+                <div class="appStore-login-2fa-devices">
+                  <div class="alert alert-info">
+                    <p>Your Apple ID is protected with two-step verification.</p>
+                  </div>
+                  <div class="form-group">
+                    <div class="col-sm-4 control-label">
+                      <label>Select a trusted number to receive a verification code</label>
+                    </div>
+                    <div class="col-sm-8">
+                      <div class="btn-group-vertical btn-block" id="fl-store-2fa-select"></div>
+                    </div>
+                  </div>
+                </div>
+                <div class="appStore-login-2fa-waiting">
+                  <div class="text-center"><i class="fa fa-spinner fa-pulse fa-lg"></i></div>
+                </div>
+                <div class="appStore-login-2fa-code">
+                  <div class="alert alert-info">
+                    <p>Apple has sent a verification code to your device(s) from <span class="region-server-location">one of Fliplet's server locations</span>. Please enter the code to continue.</p>
+                    <p><strong>Note:</strong> If you don't receive the code, please check your Apple account settings.</p>
+                  </div>
+                  <div class="form-group">
+                    <div class="col-sm-4 control-label">
+                      <label>Verify your identity</label>
+                    </div>
+                    <div class="col-sm-8">
+                      <input type="text" class="form-control" id="fl-store-2fa-code" data-error="You must enter the verification code to continue" placeholder="Enter the verification code" required>
+                      <p class="help-block appStore-2fa-sms"><strong>Did not get a verification code?</strong> <a href="#">Get a text message with a code</a></p>
+                      <div class="help-block with-errors"></div>
+                    </div>
+                  </div>
+                  <div class="form-group">
+                    <div class="col-sm-8 col-sm-offset-4">
+                      <button type="button" class="btn btn-primary 2fa-code-store-button">Verify</button>
                     </div>
                   </div>
                 </div>
@@ -952,7 +989,7 @@
                   <div class="col-sm-8">
                     <input type="text" name="fl-store-phone" class="form-control" id="fl-store-phone" pattern="\+[0-9 ]+" data-error="Please enter a valid phone number" required />
                     <div class="help-block with-errors"></div>
-                    <p class="help-block"><small>The phone number needs to include the area code. (Eg.: +44)</small></p>
+                    <p class="help-block"><small>The phone number needs to include the area code. (e.g. +44)</small></p>
                   </div>
                 </div>
                 <div class="form-group clearfix">
@@ -1018,7 +1055,7 @@
                   </div>
                   <div class="col-sm-8">
                     <input type="text" name="fl-store-revPhone" class="form-control" id="fl-store-revPhone" pattern="\+[0-9 ]+" data-error="Please enter a valid phone number" required />
-                    <p class="help-block"><small>The phone number needs to include the area code. (Eg.: +44)</small></p>
+                    <p class="help-block"><small>The phone number needs to include the area code. (e.g. +44)</small></p>
                     <div class="help-block with-errors"></div>
                   </div>
                 </div>
@@ -1189,6 +1226,43 @@ If you have any questions please reply and I will be happy to answer any questio
                       <button type="button" class="btn btn-primary login-enterprise-button">Log in</button> or <a href="#" class="ent-enter-manually">Enter details manually</a>
                       <div class="text-danger login-error"></div>
                       <p class="help-block">If you don't want to store the Apple developer account login details in Fliplet click the <i>Enter details manually</i> link.</p>
+                    </div>
+                  </div>
+                </div>
+                <div class="enterprise-login-2fa-devices">
+                  <div class="alert alert-info">
+                    <p>Your Apple ID is protected with two-step verification.</p>
+                  </div>
+                  <div class="form-group">
+                    <div class="col-sm-4 control-label">
+                      <label>Select a trusted number to receive a verification code</label>
+                    </div>
+                    <div class="col-sm-8">
+                      <div class="btn-group-vertical btn-block" id="fl-ent-2fa-select"></div>
+                    </div>
+                  </div>
+                </div>
+                <div class="enterprise-login-2fa-waiting">
+                  <div class="text-center"><i class="fa fa-spinner fa-pulse fa-lg"></i></div>
+                </div>
+                <div class="enterprise-login-2fa-code">
+                  <div class="alert alert-info">
+                    <p>Apple has sent a verification code to your device(s) from <span class="region-server-location">one of Fliplet's server locations</span>. Please enter the code to continue.</p>
+                    <p><strong>Note:</strong> If you don't receive the code, please check your Apple account settings.</p>
+                  </div>
+                  <div class="form-group">
+                    <div class="col-sm-4 control-label">
+                      <label>Verify your identity</label>
+                    </div>
+                    <div class="col-sm-8">
+                      <input type="text" class="form-control" id="fl-ent-2fa-code" data-error="You must enter the verification code to continue" placeholder="Enter the verification code" required>
+                      <p class="help-block enterprise-2fa-sms"><strong>Did not get a verification code?</strong> <a href="#">Get a text message with a code</a></p>
+                      <div class="help-block with-errors"></div>
+                    </div>
+                  </div>
+                  <div class="form-group">
+                    <div class="col-sm-8 col-sm-offset-4">
+                      <button type="button" class="btn btn-primary 2fa-code-ent-button">Verify</button>
                     </div>
                   </div>
                 </div>

--- a/js/interface.js
+++ b/js/interface.js
@@ -2047,7 +2047,7 @@ function getCurrentLoginForm() {
 
 function toggleLoginForm(form, state, data) {
   // form @param (String) app-store | enterprise
-  // state @param (String) login | logging-in | 2fa-device | 2fa-waiting | 2fa-code | 2fa-verifying | 2fa-sms | logged-in
+  // state @param (String) login | logging-in | 2fa-device | 2fa-waiting | 2fa-code | 2fa-verifying | logged-in
   // data @param (Object) Data for configuring forms (Optional)
 
   var selectors = {
@@ -2144,13 +2144,12 @@ function toggleLoginForm(form, state, data) {
         required: true,
         readonly: false
       }).focus();
+      // Show SMS option if allowed
+      $(sel.mfaSms)[data.smsAllowed ? 'addClass' : 'removeClass']('show');
       $(sel.mfaCodeButton).html('Verify').prop('disabled', false);
       $([sel.emailField, sel.passwordField, sel.mfaDeviceField].join(',')).prop('required', false);
       $(sel.loginDetails).addClass('hidden');
-      $([sel.mfaDevices, sel.mfaSms, sel.mfaCodeWaiting, sel.loggedIn, sel.moreOptions, sel.teams].join(',')).removeClass('show');
-      break;
-    case '2fa-sms':
-      $(sel.mfaSms).addClass('show');
+      $([sel.mfaDevices, sel.mfaCodeWaiting, sel.loggedIn, sel.moreOptions, sel.teams].join(',')).removeClass('show');
       break;
     case '2fa-verifying':
       $(sel.mfaCodeField).prop('readonly', true);
@@ -3141,20 +3140,13 @@ $('.browse-files').on('click', function (e) {
 socket.on('aab.apple.login.2fa', function (data) {
   socketClientId = data.clientId;
   // Ask user for code
-  toggleLoginForm(getCurrentLoginForm(), '2fa-code');
+  toggleLoginForm(getCurrentLoginForm(), '2fa-code', data);
 });
 
 socket.on('aab.apple.login.2fa.devices', function (data) {
   socketClientId = data.clientId;
   // Ask user for device
   toggleLoginForm(getCurrentLoginForm(), '2fa-device', data);
-});
-
-socket.on('aab.apple.login.2fa.sms.allowed', function () {
-  // Add SMS option
-  setTimeout(function () {
-    toggleLoginForm(getCurrentLoginForm(), '2fa-sms');
-  }, 2000);
 });
 
 /* INIT */

--- a/js/interface.js
+++ b/js/interface.js
@@ -2045,7 +2045,7 @@ function getCurrentLoginForm() {
   return ids[id];
 }
 
-function getSelectors(selectors, keys) {
+function mapSelectors(selectors, keys) {
   selectors = selectors || {};
 
   if (typeof keys === 'string') {
@@ -2111,22 +2111,22 @@ function toggleLoginForm(form, state, data) {
 
   switch (state) {
     case 'login':
-      $(getSelectors(sel, ['emailField', 'passwordField'])).prop({
+      $(mapSelectors(sel, ['emailField', 'passwordField'])).prop({
         readonly: false,
         required: true
       });
-      $(getSelectors(sel, ['mfaDeviceField', 'mfaCodeField'])).prop('required', false);
+      $(mapSelectors(sel, ['mfaDeviceField', 'mfaCodeField'])).prop('required', false);
       $(sel.loginButton).html('Log in').removeClass('disabled');
       $(sel.loginDetails).removeClass('hidden');
-      $(getSelectors(sel, ['mfaDevices', 'mfaCode', 'loggedIn', 'moreOptions', 'teams'])).removeClass('show');
+      $(mapSelectors(sel, ['mfaDevices', 'mfaCode', 'loggedIn', 'moreOptions', 'teams'])).removeClass('show');
       break;
     case 'logging-in':
-      $(getSelectors(['emailField', 'passwordField'])).prop({
+      $(mapSelectors(['emailField', 'passwordField'])).prop({
         readonly: true
       });
       $(sel.loginButton).html('Logging in ' + spinner).addClass('disabled');
       $(sel.loginDetails).removeClass('hidden');
-      $(getSelectors(sel, ['mfaDevices', 'mfaCode', 'loggedIn', 'moreOptions', 'teams'])).removeClass('show');
+      $(mapSelectors(sel, ['mfaDevices', 'mfaCode', 'loggedIn', 'moreOptions', 'teams'])).removeClass('show');
       break;
     case '2fa-device':
       var options = _.map(_.get(data, 'devices', []), function eachDevice(device, i) {
@@ -2136,19 +2136,19 @@ function toggleLoginForm(form, state, data) {
           '</span>'
         ].join('');
       }).join('');
-      $(getSelectors(sel, ['emailField', 'passwordField', 'mfaCodeField'])).prop({
+      $(mapSelectors(sel, ['emailField', 'passwordField', 'mfaCodeField'])).prop({
         required: false
       });
       $(sel.mfaDeviceField).html(options).find('input').prop('required', true);
-      $(getSelectors(sel, ['emailField', 'passwordField', 'mfaCodeField'])).prop('required', false);
+      $(mapSelectors(sel, ['emailField', 'passwordField', 'mfaCodeField'])).prop('required', false);
       $(sel.mfaDevices).addClass('show');
       $(sel.loginDetails).addClass('hidden');
-      $(getSelectors(sel, ['mfaCodeWaiting', 'mfaCode', 'loggedIn', 'moreOptions', 'teams'])).removeClass('show');
+      $(mapSelectors(sel, ['mfaCodeWaiting', 'mfaCode', 'loggedIn', 'moreOptions', 'teams'])).removeClass('show');
       break;
     case '2fa-waiting':
       $(sel.mfaCodeWaiting).addClass('show');
-      $(getSelectors(sel, ['mfaDeviceField', 'mfaCodeField'])).prop('required', false);
-      $(getSelectors(sel, ['mfaCode', 'mfaDevices', 'mfaSms'])).removeClass('show');
+      $(mapSelectors(sel, ['mfaDeviceField', 'mfaCodeField'])).prop('required', false);
+      $(mapSelectors(sel, ['mfaCode', 'mfaDevices', 'mfaSms'])).removeClass('show');
       break;
     case '2fa-code':
       $(sel.mfaCode).addClass('show');
@@ -2159,23 +2159,23 @@ function toggleLoginForm(form, state, data) {
       // Show SMS option if allowed
       $(sel.mfaSms)[data.smsAllowed ? 'addClass' : 'removeClass']('show');
       $(sel.mfaCodeButton).html('Verify').prop('disabled', false);
-      $(getSelectors(sel, 'emailField, passwordField, mfaDeviceField')).prop('required', false);
+      $(mapSelectors(sel, 'emailField, passwordField, mfaDeviceField')).prop('required', false);
       $(sel.loginDetails).addClass('hidden');
-      $(getSelectors(sel, ['mfaDevices', 'mfaCodeWaiting', 'loggedIn', 'moreOptions', 'teams'])).removeClass('show');
+      $(mapSelectors(sel, ['mfaDevices', 'mfaCodeWaiting', 'loggedIn', 'moreOptions', 'teams'])).removeClass('show');
       break;
     case '2fa-verifying':
       $(sel.mfaCodeField).prop('readonly', true);
       $(sel.mfaCodeButton).html('Verifying ' + spinner).prop('disabled', true);
       break;
     case 'logged-in':
-      $(getSelectors(sel, ['emailField', 'passwordField', 'mfaDeviceField', 'mfaCodeField'])).prop({
+      $(mapSelectors(sel, ['emailField', 'passwordField', 'mfaDeviceField', 'mfaCodeField'])).prop({
         required: false
       });
       $(sel.emailField).val(data.email);
       $(sel.loggedInEmail).html(data.email);
       $(sel.loginDetails).addClass('hidden');
-      $(getSelectors(sel, ['loggedIn', 'teams'])).addClass('show');
-      $(getSelectors(sel, ['mfaDevices', 'mfaCode'])).removeClass('show');
+      $(mapSelectors(sel, ['loggedIn', 'teams'])).addClass('show');
+      $(mapSelectors(sel, ['mfaDevices', 'mfaCode'])).removeClass('show');
       break;
   }
 

--- a/js/interface.js
+++ b/js/interface.js
@@ -2045,6 +2045,18 @@ function getCurrentLoginForm() {
   return ids[id];
 }
 
+function getSelectors(selectors, keys) {
+  selectors = selectors || {};
+
+  if (typeof keys === 'string') {
+    keys = [keys];
+  }
+
+  keys = keys || [];
+
+  return _.values(_.pick(selectors, keys)).join(',');
+}
+
 function toggleLoginForm(form, state, data) {
   // form @param (String) app-store | enterprise
   // state @param (String) login | logging-in | 2fa-device | 2fa-waiting | 2fa-code | 2fa-verifying | logged-in
@@ -2099,22 +2111,22 @@ function toggleLoginForm(form, state, data) {
 
   switch (state) {
     case 'login':
-      $([sel.emailField, sel.passwordField].join(',')).prop({
+      $(getSelectors(sel, ['emailField', 'passwordField'])).prop({
         readonly: false,
         required: true
       });
-      $([sel.mfaDeviceField, sel.mfaCodeField].join(',')).prop('required', false);
+      $(getSelectors(sel, ['mfaDeviceField', 'mfaCodeField'])).prop('required', false);
       $(sel.loginButton).html('Log in').removeClass('disabled');
       $(sel.loginDetails).removeClass('hidden');
-      $([sel.mfaDevices, sel.mfaCode, sel.loggedIn, sel.moreOptions, sel.teams].join(',')).removeClass('show');
+      $(getSelectors(sel, ['mfaDevices', 'mfaCode', 'loggedIn', 'moreOptions', 'teams'])).removeClass('show');
       break;
     case 'logging-in':
-      $([sel.emailField, sel.passwordField].join(',')).prop({
+      $(getSelectors(['emailField', 'passwordField'])).prop({
         readonly: true
       });
       $(sel.loginButton).html('Logging in ' + spinner).addClass('disabled');
       $(sel.loginDetails).removeClass('hidden');
-      $([sel.mfaDevices, sel.mfaCode, sel.loggedIn, sel.moreOptions, sel.teams].join(',')).removeClass('show');
+      $(getSelectors(sel, ['mfaDevices', 'mfaCode', 'loggedIn', 'moreOptions', 'teams'])).removeClass('show');
       break;
     case '2fa-device':
       var options = _.map(_.get(data, 'devices', []), function eachDevice(device, i) {
@@ -2124,19 +2136,19 @@ function toggleLoginForm(form, state, data) {
           '</span>'
         ].join('');
       }).join('');
-      $([sel.emailField, sel.passwordField, sel.mfaCodeField].join(',')).prop({
+      $(getSelectors(sel, ['emailField', 'passwordField', 'mfaCodeField'])).prop({
         required: false
       });
       $(sel.mfaDeviceField).html(options).find('input').prop('required', true);
-      $([sel.emailField, sel.passwordField, sel.mfaCodeField].join(',')).prop('required', false);
+      $(getSelectors(sel, ['emailField', 'passwordField', 'mfaCodeField'])).prop('required', false);
       $(sel.mfaDevices).addClass('show');
       $(sel.loginDetails).addClass('hidden');
-      $([sel.mfaCode, sel.loggedIn, sel.moreOptions, sel.teams].join(',')).removeClass('show');
+      $(getSelectors(sel, ['mfaCodeWaiting', 'mfaCode', 'loggedIn', 'moreOptions', 'teams'])).removeClass('show');
       break;
     case '2fa-waiting':
       $(sel.mfaCodeWaiting).addClass('show');
-      $([sel.mfaDeviceField, sel.mfaCodeField].join(',')).prop('required', false);
-      $([sel.mfaCode, sel.mfaDevices, sel.mfaSms].join(',')).removeClass('show');
+      $(getSelectors(sel, ['mfaDeviceField', 'mfaCodeField'])).prop('required', false);
+      $(getSelectors(sel, ['mfaCode', 'mfaDevices', 'mfaSms'])).removeClass('show');
       break;
     case '2fa-code':
       $(sel.mfaCode).addClass('show');
@@ -2147,23 +2159,23 @@ function toggleLoginForm(form, state, data) {
       // Show SMS option if allowed
       $(sel.mfaSms)[data.smsAllowed ? 'addClass' : 'removeClass']('show');
       $(sel.mfaCodeButton).html('Verify').prop('disabled', false);
-      $([sel.emailField, sel.passwordField, sel.mfaDeviceField].join(',')).prop('required', false);
+      $(getSelectors(sel, 'emailField, passwordField, mfaDeviceField')).prop('required', false);
       $(sel.loginDetails).addClass('hidden');
-      $([sel.mfaDevices, sel.mfaCodeWaiting, sel.loggedIn, sel.moreOptions, sel.teams].join(',')).removeClass('show');
+      $(getSelectors(sel, ['mfaDevices', 'mfaCodeWaiting', 'loggedIn', 'moreOptions', 'teams'])).removeClass('show');
       break;
     case '2fa-verifying':
       $(sel.mfaCodeField).prop('readonly', true);
       $(sel.mfaCodeButton).html('Verifying ' + spinner).prop('disabled', true);
       break;
     case 'logged-in':
-      $([sel.emailField, sel.passwordField, sel.mfaDeviceField, sel.mfaCodeField].join(',')).prop({
+      $(getSelectors(sel, ['emailField', 'passwordField', 'mfaDeviceField', 'mfaCodeField'])).prop({
         required: false
       });
       $(sel.emailField).val(data.email);
       $(sel.loggedInEmail).html(data.email);
       $(sel.loginDetails).addClass('hidden');
-      $([sel.loggedIn, sel.teams].join(',')).addClass('show');
-      $([sel.mfaDevices, sel.mfaCode].join(',')).removeClass('show');
+      $(getSelectors(sel, ['loggedIn', 'teams'])).addClass('show');
+      $(getSelectors(sel, ['mfaDevices', 'mfaCode'])).removeClass('show');
       break;
   }
 

--- a/js/interface.js
+++ b/js/interface.js
@@ -2285,7 +2285,10 @@ $('.panel-group')
 $('a[data-toggle="tab"]')
   .on('shown.bs.tab', function () {
     Fliplet.Widget.autosize();
-    socket.to(socketClientId).emit('aab.apple.login.2fa.cancel');
+
+    if (socketClientId) {
+      socket.to(socketClientId).emit('aab.apple.login.2fa.cancel');
+    }
   })
   .on('hidden.bs.tab', function () {
     Fliplet.Widget.autosize();

--- a/js/interface.js
+++ b/js/interface.js
@@ -2190,6 +2190,14 @@ $('#fl-store-2fa-select, #fl-ent-2fa-select').on('change', function (e) {
 
 $('.2fa-code-store-button, .2fa-code-ent-button').on('click', function (e) {
   var code = $(this).parents('.form-group').prev().find('.form-control').val();
+
+  if (!code) {
+    Fliplet.Modal.alert({
+      message: 'You must enter the verification code to continue'
+    });
+    return;
+  }
+
   toggleLoginForm(getCurrentLoginForm(), '2fa-verifying');
   socket.to(socketClientId).emit('aab.apple.login.2fa.code', code);
 });


### PR DESCRIPTION
### Objectives

- Add support for 2FA within the AAB UI, without needing to interact with `Fliplet.Modal` for entering 2FA
- Supports more possible states provided by Apple 2FA, as outlined in https://github.com/Fliplet/fliplet-api/pull/3193
- Make it easier for AAB login form states to manage

### Changes

- [x] Refactored to use centralised method for login form toggling
- [x] Added UI for entering 2FA code
- [x] Added integration with API
- [x] Errors and form validation
