### PR TITLE
Adds support for new screenshot size requirements

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -119,6 +119,10 @@
   border-color: #a94442;
 }
 
+.panel-default.required-fill + .panel-default:not(.required-fill) {
+  margin-top: 0;
+}
+
 .app-details-error,
 .app-details-warning {
   display: none;
@@ -476,26 +480,18 @@ h3 small {
   margin-top: 10px;
 }
 
-.hidden-area {
-  display: none;
-  background-color: #f2f6f7;
-  border-radius: 6px;
-  padding: 15px 15px 1px 15px;
+.alert-inset {
   margin-top: 10px;
   margin-bottom: 20px;
   margin-left: 25px;
 }
 
-.hidden-area.warning {
-  color: #8a6d3b;
-  background-color: #fcf8e3;
-  border: 1px solid #faebcc;
+.alert > p, .alert > ul {
+  margin-bottom: 10px;
 }
 
-.hidden-area.danger {
-  color: #a94442;
-  background-color: #f2dede;
-  border-color: #ebccd1;
+.alert > p:fist-child:last-child, .alert > ul:fist-child:last-child {
+  margin-bottom: 0;
 }
 
 .radio.radio-icon ~ .radio.radio-icon,
@@ -520,4 +516,8 @@ h3 small {
 
 .screenshot-previews img {
   border: 1px solid #F0F0F0;
+}
+
+.screenshot-previews .alert {
+  margin-bottom: 0;
 }

--- a/interface.html
+++ b/interface.html
@@ -84,23 +84,13 @@
                       </label>
                     </div>
 
-                    <div data-item="fl-store-screenshots-new-warning" class="hidden-area danger">
-                      <p>Apple requires you to upload up to 4 screenshots of your app for mobile and tablet devices. We could not find any screenshots in your folders, please go to <a href="#" onclick="Fliplet.Studio.emit('navigate', { name: 'launchAssets' })">App Settings</a> to generate your screenshots.</p>
+                    <div data-item="fl-store-screenshots-new-warning" class="alert alert-inset alert-danger hidden">
+                      <p>Apple requires you to upload up to 4 screenshots of your app for all the device types listed below. Please go to <a href="#" data-change-assets>App Settings</a> to generate your screenshots.</p>
                     </div>
-                    <div data-item="fl-store-screenshots-new" class="hidden-area">
-                      <p>We will use the following screenshot in your app listing in the order shown below.<br>
-                      <small>We order the screenshots alphabetically, to reorder go to <a href="#" class="browse-files">File Manager</a> and rename your screenshots.</small></p>
-
-                      <div class="row screenshot-previews">
-                        <div class="col-xs-12"><strong>Mobile</strong></div>
-                        <div class="mobile-thumbs"></div>
-                      </div>
-                      <div class="row screenshot-previews">
-                        <div class="col-xs-12"><strong>Tablet</strong></div>
-                        <div class="tablet-thumbs"></div>
-                      </div>
-
-                      <p>If you want to generate or upload new screenshots go to <a href="#" onclick="Fliplet.Studio.emit('navigate', { name: 'launchAssets' })">App Settings</a>.</p>
+                    <div data-item="fl-store-screenshots-mobilex-missing" class="alert alert-inset alert-warning hidden">Starting <strong>March 27, 2019</strong> all new apps and app updates for iPhone or iPad need to include screenshots for the iPhone 6.5-inch display.</div>
+                    <div data-item="fl-store-screenshots-new" class="alert alert-inset alert-info hidden">
+                      <p>We will use the following screenshots in your app listing in the order shown below. <strong>Screenshots are uploaded alphabetically.</strong> To reorder them, go to <a href="#" class="browse-files">File Manager</a> and rename your screenshots. To generate or upload new screenshots go to <a href="#" data-change-assets>App Settings</a>.</p>
+                      <div class="screenshot-thumb-containers"></div>
                     </div>
 
                     <div class="radio radio-icon">
@@ -110,9 +100,9 @@
                       </label>
                     </div>
 
-                    <div data-item="fl-store-screenshots-existing" class="hidden-area">
-                      <p>We will not upload new screenshots, we will use the existing screenshots on the app listing. By selecting this option you are confirming that you already have an app listing on the Apple App Store and that it contains the screenshots you want to be publicaly available.</p>
-                      <p class="text-warning">The app submission will fail if the app listing doesn’t contain screenshots.</p>
+                    <div data-item="fl-store-screenshots-existing" class="alert alert-inset alert-warning hidden">
+                      <p>Apple will use the existing screenshots on the app listing and we will not upload new screenshots. By selecting this option you are confirming that you already have an app listing on the Apple App Store and that it contains the screenshots you want to be publicly available.</p>
+                      <p><strong>The app submission will fail if the app listing doesn’t contain all required screenshots.</strong></p>
                     </div>
 
                   </div>

--- a/js/interface.js
+++ b/js/interface.js
@@ -40,19 +40,19 @@ var hasFolders = false;
 var screenshotRequirements = [
   {
     type: 'mobile',
-    name: 'iPhone 5.5-inch Display',
+    name: 'iPhone 5.5-inch',
     sizes: [[1242, 2208]],
     screenshots: []
   },
   {
     type: 'mobilex',
-    name: 'iPhone 6.5-inch Display',
+    name: 'iPhone 6.5-inch',
     sizes: [[1242, 2688]],
     screenshots: []
   },
   {
     type: 'tablet',
-    name: 'iPad Pro 12.9-inch Display',
+    name: 'iPad Pro 12.9-inch',
     sizes: [[2048, 2732], [2732, 2048]],
     screenshots: []
   }

--- a/js/interface.templates.js
+++ b/js/interface.templates.js
@@ -2,10 +2,43 @@ this["Fliplet"] = this["Fliplet"] || {};
 this["Fliplet"]["Widget"] = this["Fliplet"]["Widget"] || {};
 this["Fliplet"]["Widget"]["Templates"] = this["Fliplet"]["Widget"]["Templates"] || {};
 
+this["Fliplet"]["Widget"]["Templates"]["templates.no-thumb"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
+    var helper;
+
+  return "<div class=\"col-xs-12\">\n  <div class=\"alert alert-danger\">Apple requires you to upload up to 4 screenshots of your app for <strong>"
+    + container.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"name","hash":{},"data":data}) : helper)))
+    + "</strong>. To generate your screenshots, go to <a href=\"#\" data-change-assets=\"\">App Settings</a>.</div>\n</div>";
+},"useData":true});
+
+this["Fliplet"]["Widget"]["Templates"]["templates.thumb-containers"] = Handlebars.template({"1":function(container,depth0,helpers,partials,data) {
+    var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
+
+  return "<div class=\"row screenshot-previews\">\n  <div class=\"col-xs-12\"><p><strong>"
+    + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
+    + "</strong><br>"
+    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.sizes : depth0),{"name":"each","hash":{},"fn":container.program(2, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "</p></div>\n  <div class=\"thumbs\" data-type=\""
+    + alias4(((helper = (helper = helpers.type || (depth0 != null ? depth0.type : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"type","hash":{},"data":data}) : helper)))
+    + "\"></div>\n</div>\n";
+},"2":function(container,depth0,helpers,partials,data) {
+    var stack1, alias1=container.lambda, alias2=container.escapeExpression;
+
+  return ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.first),{"name":"unless","hash":{},"fn":container.program(3, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + alias2(alias1((depth0 != null ? depth0["0"] : depth0), depth0))
+    + " &times; "
+    + alias2(alias1((depth0 != null ? depth0["1"] : depth0), depth0));
+},"3":function(container,depth0,helpers,partials,data) {
+    return " or ";
+},"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
+  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),depth0,{"name":"each","hash":{},"fn":container.program(1, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "");
+},"useData":true});
+
 this["Fliplet"]["Widget"]["Templates"]["templates.thumbs"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
     var helper;
 
   return "<div class=\"col-xs-3\">\n  <img src=\""
     + container.escapeExpression(((helper = (helper = helpers.url || (depth0 != null ? depth0.url : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"url","hash":{},"data":data}) : helper)))
-    + "\"/>\n</div>";
+    + "\" />\n</div>";
 },"useData":true});

--- a/js/templates/no-thumb.interface.hbs
+++ b/js/templates/no-thumb.interface.hbs
@@ -1,0 +1,3 @@
+<div class="col-xs-12">
+  <div class="alert alert-danger">Apple requires you to upload up to 4 screenshots of your app for <strong>{{ name }}</strong>. To generate your screenshots, go to <a href="#" data-change-assets="">App Settings</a>.</div>
+</div>

--- a/js/templates/thumb-containers.interface.hbs
+++ b/js/templates/thumb-containers.interface.hbs
@@ -1,0 +1,6 @@
+{{#each this}}
+<div class="row screenshot-previews">
+  <div class="col-xs-12"><p><strong>{{ name }}</strong><br>{{#each sizes}}{{#unless @first}} or {{/unless}}{{this.[0]}} &times; {{this.[1]}}{{/each}}</p></div>
+  <div class="thumbs" data-type="{{ type }}"></div>
+</div>
+{{/each}}

--- a/js/templates/thumbs.interface.hbs
+++ b/js/templates/thumbs.interface.hbs
@@ -1,3 +1,3 @@
 <div class="col-xs-3">
-  <img src="{{url}}"/>
+  <img src="{{url}}" />
 </div>


### PR DESCRIPTION
Requires https://github.com/Fliplet/fliplet-studio/pull/4096

Adds support for new screenshot size requirements as per upcoming changes from Apple. This adds support for the 1242 x 2688 screenshot for iPhone XS Max.

It also updates the validation to be more specific about which screenshots are missing.