### PR TITLE
Avoid app-specific passwords from being reset

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -1479,13 +1479,6 @@ function getCredential(credentialKey) {
   return Fliplet.API.request({
     method: 'GET',
     url: 'v1/organizations/' + organizationID + '/credentials/' + credentialKey
-  }).then(function (credential) {
-    if (!credential || !credential.email) {
-      // Valid credential email not found
-      return Promise.resolve();
-    }
-
-    return Promise.resolve(credential);
   }).catch(function (error) {
     if (error && error.status === 404) {
       // Credential not found


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/4601

The function callers are already running validation checks, so it's safe to remove the validation.