### PR TITLE
When app is successfully requested, Modal window opens and page scrolls to 'building app' section

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -292,9 +292,6 @@ h3 small {
 .save-appStore-progress,
 .save-enterprise-progress,
 .save-unsigned-progress,
-.save-appStore-request,
-.save-enterprise-request,
-.save-unsigned-request,
 .save-push-progress {
   opacity: 0;
   -webkit-transition: opacity 0.25s ease;
@@ -304,9 +301,6 @@ h3 small {
 .save-appStore-progress.saved,
 .save-enterprise-progress.saved,
 .save-unsigned-progress.saved,
-.save-appStore-request.saved,
-.save-enterprise-request.saved,
-.save-unsigned-request.saved,
 .save-push-progress.saved {
   opacity: 1;
 }

--- a/interface.html
+++ b/interface.html
@@ -1,5 +1,5 @@
 <div class="form-horizontal">
-  <ul class="nav nav-tabs" role="tablist">
+  <ul class="nav nav-tabs" role="tablist" id="nav-tabs">
     <li role="presentation" class="active" id="appstore-control">
       <a href="#appstore-tab" aria-controls="appstore" role="tab" data-toggle="tab">
         <span>App Store</span>
@@ -1154,7 +1154,6 @@ If you have any questions please reply and I will be happy to answer any questio
         <div class="col-xs-5 save-btn-holder col-xs-offset-2 text-right">
           <p class="help-block"><small>Submit your information when you are ready!<br>We will take care of the rest.</small></p>
           <button type="submit" class="btn btn-primary fl-green button-appStore-request" data-app-store-build>Request App <i class="fa fa-paper-plane"></i></button>
-          <p class="text-success save-appStore-request">Your request was sent successfully!</p>
         </div>
       </form>
     </div>
@@ -1544,7 +1543,6 @@ If you have any questions please reply and I will be happy to answer any questio
         <div class="col-xs-5 save-btn-holder col-xs-offset-2 text-right">
           <p class="help-block"><small>Submit your information when you are ready!<br>We will take care of the rest.</small></p>
           <button type="submit" class="btn btn-primary fl-green button-enterprise-request" data-enterprise-build>Request App <i class="fa fa-paper-plane"></i></button>
-          <p class="text-success save-enterprise-request">Your request was sent successfully!</p>
         </div>
       </form>
     </div>
@@ -1706,7 +1704,6 @@ If you have any questions please reply and I will be happy to answer any questio
         <div class="col-xs-5 save-btn-holder col-xs-offset-2 text-right">
           <p class="help-block"><small>Submit your information when you are ready!<br>We will take care of the rest.</small></p>
           <button type="submit" class="btn btn-primary fl-green button-unsigned-request" data-unsigned-build>Request App <i class="fa fa-paper-plane"></i></button>
-          <p class="text-success save-unsigned-request">Your request was sent successfully!</p>
         </div>
       </form>
     </div>

--- a/js/interface.js
+++ b/js/interface.js
@@ -700,21 +700,20 @@ function submissionBuild(appSubmission, origin) {
 
     Fliplet.Studio.emit('refresh-app-submissions');
 
+    Fliplet.Modal.alert({
+      title: 'Your request was sent successfully!',
+      message: 'Your app is building!'
+    }).then(function () {
+      document.getElementById('nav-tabs').scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+
     $('.button-' + origin + '-request').html('Request App <i class="fa fa-paper-plane"></i>');
     $('.button-' + origin + '-request').prop('disabled', false);
-    $('.save-' + origin + '-request').addClass('saved').hide().fadeIn(250);
 
     clearTimeout(initLoad);
     initialLoad(false, 0);
 
     Fliplet.Widget.autosize();
-
-    setTimeout(function () {
-      $('.save-' + origin + '-request').fadeOut(250, function () {
-        $('.save-' + origin + '-request').removeClass('saved');
-        Fliplet.Widget.autosize();
-      });
-    }, 10000);
   }, function (err) {
     $('.button-' + origin + '-request').html('Request App <i class="fa fa-paper-plane"></i>');
     $('.button-' + origin + '-request').prop('disabled', false);


### PR DESCRIPTION
@tonytlwu @squallstar

## Issue
Fliplet/fliplet-studio#2832

## Description
Now when the app is successfully requested, Modal window is fired. After confirming it, the page gets scrolled to 'building app' section.
Removed green text 'Your request was sent successfully!' under Request App button and all CSS related to it.

## Screenshots/screencasts
Edge
![edge go up fix](https://user-images.githubusercontent.com/52824207/65018484-e891b980-d931-11e9-9e6c-e7fd4b0f3ce2.gif)

Chrome
![Apple demo](https://user-images.githubusercontent.com/52824207/65018506-f6dfd580-d931-11e9-9582-3d2a96ea6ac8.gif)

## Backward compatibility
This change is fully backward compatible.

## Notes
Behavior: "smooth" attribute that gives smooth scrolling works only on Chrome, Firefox, Opera. Other browsers (IE, Edge) will scroll page instantly.



