### PR TITLE
Tabs will be scrolled to the top of the content when they open

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -2601,6 +2601,14 @@ $('.fl-sb-appStore [change-bundleid], .fl-sb-enterprise [change-bundleid], .fl-s
 $('.panel-group')
   .on('shown.bs.collapse', '.panel-collapse', function () {
     Fliplet.Widget.autosize();
+
+    var $panel = $(this).closest('.panel');
+
+    if (!$panel || !$panel.offset()) {
+      return;
+    }
+  
+    Fliplet.Studio.emit('scrollOverlayTo', $panel.offset().top);
   })
   .on('hidden.bs.collapse', '.panel-collapse', function () {
     Fliplet.Widget.autosize();


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/2149

## Description
Tabs will be scrolled to the top of the content when they open

## Backward compatibility

This change is fully backward compatible.
