### PR TITLE
User will see an error message if he tries to input white-spaces in icon name

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -1601,7 +1601,7 @@ If you have any questions please reply and I will be happy to answer any questio
                     <p class="help-block label-helper"><small>The name below the icon on the home screen. Note that the app icon name will only display a maximum of 13 characters</small></p>
                   </div>
                   <div class="col-sm-8">
-                    <input type="text" name="fl-uns-iconName" class="form-control" id="fl-uns-iconName" maxlength="30" data-error="Please enter an app icon name" required />
+                    <input pattern="^(?!\s*$).+" type="text" name="fl-uns-iconName" class="form-control" id="fl-uns-iconName" maxlength="30" data-error="Please enter an app icon name" required />
                     <div class="help-block with-errors"></div>
                     <p class="help-block"><small>App names are limited to 30 characters.</small></p>
                   </div>


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5949

## Description
User will see an error message if he tries to input white-spaces in the icon name

## Screenshots/screencasts
https://share.getcloudapp.com/DOu8b5vj

## Backward compatibility

This change is fully backward compatible.

## Notes
You may test regex that we use [here](https://www.regextester.com/?fam=115635).

## Reviewers 
@upplabs-alex-levchenko @MaksymShokin 