### PR TITLE
ID-2119 [Fix] Restrict to numbers in semantic versioning

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -1157,7 +1157,7 @@ If you have any questions please reply and I will be happy to answer any questio
                     <p class="help-block label-helper"><small>This is the version number of your app and will be displayed on the App Store listing.</small></p>
                   </div>
                   <div class="col-sm-8">
-                    <input type="text" name="fl-store-versionNumber" class="form-control" id="fl-store-versionNumber" pattern="^.{1,}\..{1,}\..{1,}$" data-error="Please enter a version number in the required format" data-required-error="Please enter an app version number" data-validation-version-number-type="" data-validation-version-number-type-error="" data-validation-version-number="" data-validation-version-number-error="Please make sure the version number is higher than 1.0.0" maxlength="155" required />
+                    <input type="text" name="fl-store-versionNumber" class="form-control" id="fl-store-versionNumber" pattern="^\d+\.\d+\.\d+$" data-error="Please enter a version number in the required format" data-required-error="Please enter an app version number" data-validation-version-number-type="" data-validation-version-number-type-error="" data-validation-version-number="" data-validation-version-number-error="Please make sure the version number is higher than 1.0.0" maxlength="155" required />
                     <div class="help-block with-errors"></div>
                     <p class="help-block"><small>The required format for version number is <code>x.x.x</code>, where <code>x</code> is a number, e.g. <code>1.0.0</code>.</small></p>
                   </div>
@@ -1552,7 +1552,7 @@ If you have any questions please reply and I will be happy to answer any questio
                     <p class="help-block label-helper"><small>This is the version number of your app.</small></p>
                   </div>
                   <div class="col-sm-8">
-                    <input type="text" name="fl-ent-versionNumber" class="form-control" id="fl-ent-versionNumber" pattern="^.{1,}\..{1,}\..{1,}$" data-error="Please enter a version number in the required format" data-required-error="Please enter an app version number" data-validation-version-number-type="" data-validation-version-number-type-error="" data-validation-version-number="" data-validation-version-number-error="Please make sure the version number is higher than 1.0.0" maxlength="155" required />
+                    <input type="text" name="fl-ent-versionNumber" class="form-control" id="fl-ent-versionNumber" pattern="^\d+\.\d+\.\d+$" data-error="Please enter a version number in the required format" data-required-error="Please enter an app version number" data-validation-version-number-type="" data-validation-version-number-type-error="" data-validation-version-number="" data-validation-version-number-error="Please make sure the version number is higher than 1.0.0" maxlength="155" required />
                     <div class="help-block with-errors"></div>
                     <p class="help-block"><small>The required format for version number is <code>x.x.x</code>, where <code>x</code> is a number, e.g. <code>1.0.0</code>.</small></p>
                   </div>
@@ -1720,7 +1720,7 @@ If you have any questions please reply and I will be happy to answer any questio
                     <p class="help-block label-helper"><small>This is the version number of your app.</small></p>
                   </div>
                   <div class="col-sm-8">
-                    <input type="text" name="fl-uns-versionNumber" class="form-control" id="fl-uns-versionNumber" pattern="^.{1,}\..{1,}\..{1,}$" data-error="Please enter a version number in the required format" data-required-error="Please enter an app version number" data-validation-version-number-type="" data-validation-version-number-type-error="" data-validation-version-number="" data-validation-version-number-error="Please make sure the version number is higher than 1.0.0" maxlength="155" required />
+                    <input type="text" name="fl-uns-versionNumber" class="form-control" id="fl-uns-versionNumber" pattern="^\d+\.\d+\.\d+$" data-error="Please enter a version number in the required format" data-required-error="Please enter an app version number" data-validation-version-number-type="" data-validation-version-number-type-error="" data-validation-version-number="" data-validation-version-number-error="Please make sure the version number is higher than 1.0.0" maxlength="155" required />
                     <div class="help-block with-errors"></div>
                     <p class="help-block"><small>The required format for version number is <code>x.x.x</code>, where <code>x</code> is a number, e.g. <code>1.0.0</code>.</small></p>
                   </div>

--- a/js/interface.js
+++ b/js/interface.js
@@ -2764,7 +2764,7 @@ $('form').validator({
     'validation-version-number': function($el) {
       var oldVersion = $el.data('validation-version-number');
       var newVersion = $el.val();
-      var versionRegExp = /^\d{1,}\.\d{1,}\.\d{1,}$/;
+      var versionRegExp = /^\d+\.\d+\.\d+$/;
 
       if (!oldVersion || !$el.val() || !versionRegExp.test(newVersion)) {
         return false;
@@ -2794,9 +2794,9 @@ $('form').validator({
     },
     'validation-version-number-type': function($el) {
       var newVersion = $el.val();
-      var versionRegExp = /[^\d\.]/;
+      var versionRegExp = /^\d+\.\d+\.\d+$/;
 
-      if (versionRegExp.test(newVersion) && newVersion.length > 4) {
+      if (!versionRegExp.test(newVersion)) {
         $el.attr('data-validation-version-number-type-error', 'Please make sure the app version is a number');
 
         return true;


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-2119

Fixes the following problems:

1. Version number allows non-numeric characters

Caused by https://github.com/Fliplet/fliplet-widget-google-submission/pull/61