### PR TITLE
Add support for hideStoreTab query parameter to hide App Store tab

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -3,6 +3,10 @@ var widgetData = Fliplet.Widget.getData(widgetId) || {};
 var organizationIsPaying = widgetData.organizationIsPaying;
 var mustReviewTos = widgetData.mustReviewTos;
 var storeFeatures = _.get(widgetData, 'appFeatures.appStores.apple', {});
+
+// Check for hideStoreTab query parameter
+var urlParams = new URLSearchParams(window.location.search);
+var hideStoreTab = urlParams.get('hideStoreTab') === 'true';
 var appName = '';
 var organizationName = '';
 var appIcon = '';
@@ -1886,6 +1890,14 @@ function init() {
       return app.id === Fliplet.Env.get('appId');
     });
   });
+
+  // Hide App Store tab if hideStoreTab query parameter is true
+  if (hideStoreTab) {
+    $('#appstore-control').hide();
+    $('#appstore-tab').removeClass('active');
+    $('#enterprise-control').addClass('active');
+    $('#enterprise-tab').addClass('active');
+  }
 
   $('#fl-store-keywords').tokenfield({
     createTokensOnBlur: true


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/DEV-848

## Summary

  - Add support for `hideStoreTab=true` query parameter to hide the App Store tab when the widget is opened
  - When hidden, the Enterprise tab becomes the default active tab

## Test plan

  - Open the widget normally and verify all tabs are visible with App Store tab active
  - Open the widget with ?hideStoreTab=true query parameter and verify:
    - App Store tab is hidden
    - Enterprise tab is active and visible by default
    - Other tabs (Unsigned IPA, Push Notifications) remain accessible